### PR TITLE
all: replace terraform-providers but outscale

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -11,7 +11,7 @@ default: build
 
 .PHONY: build
 build: fmtcheck
-	go build -ldflags "-X github.com/terraform-providers/terraform-provider-outscale/version.version=${VERSION}"
+	go build -ldflags "-X github.com/outscale/terraform-provider-outscale/version.version=${VERSION}"
 
 .PHONY: fmtcheck
 fmtcheck:

--- a/README.md
+++ b/README.md
@@ -84,15 +84,15 @@ export OUTSCALE_X509CERT=/myrepository/certificate/client_ca.crt
 export OUTSCALE_X509KEY=/myrepository/certificate/client_ca.key
 ```
 ## Building The Provider
-Clone repository to: `$GOPATH/src/github.com/terraform-providers/terraform-provider-outscale`
+Clone repository to: `$GOPATH/src/github.com/outscale/terraform-provider-outscale`
 ```sh
-mkdir -p $GOPATH/src/github.com/terraform-providers
-cd  $GOPATH/src/github.com/terraform-providers
+mkdir -p $GOPATH/src/github.com/outscale
+cd  $GOPATH/src/github.com/outscale
 git clone --branch v0.9.1 https://github.com/outscale/terraform-provider-outscale
 ```
 Enter the provider directory and build the provider
 ```sh
-cd  $GOPATH/src/github.com/terraform-providers/terraform-provider-outscale
+cd  $GOPATH/src/github.com/outscale/terraform-provider-outscale
 go build -o terraform-provider-outscale_v0.9.1
 ```
 ## Using the provider

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/terraform-providers/terraform-provider-outscale
+module github.com/outscale/terraform-provider-outscale
 
 go 1.12
 

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/plugin"
-	"github.com/terraform-providers/terraform-provider-outscale/outscale"
+	"github.com/outscale/terraform-provider-outscale/outscale"
 )
 
 func main() {

--- a/outscale/config.go
+++ b/outscale/config.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/logging"
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/version"
+	"github.com/outscale/terraform-provider-outscale/version"
 )
 
 // Config ...

--- a/outscale/data_source_outscale_access_key.go
+++ b/outscale/data_source_outscale_access_key.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func dataSourceOutscaleAccessKey() *schema.Resource {

--- a/outscale/data_source_outscale_access_keys.go
+++ b/outscale/data_source_outscale_access_keys.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func dataSourceOutscaleAccessKeys() *schema.Resource {

--- a/outscale/data_source_outscale_account.go
+++ b/outscale/data_source_outscale_account.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func dataSourceAccount() *schema.Resource {

--- a/outscale/data_source_outscale_accounts.go
+++ b/outscale/data_source_outscale_accounts.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func dataSourceAccounts() *schema.Resource {

--- a/outscale/data_source_outscale_api_access_policy.go
+++ b/outscale/data_source_outscale_api_access_policy.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func dataSourceOutscaleOAPIApiAccessPolicy() *schema.Resource {

--- a/outscale/data_source_outscale_api_access_rule.go
+++ b/outscale/data_source_outscale_api_access_rule.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func dataSourceOutscaleOAPIApiAccessRule() *schema.Resource {

--- a/outscale/data_source_outscale_api_access_rule_test.go
+++ b/outscale/data_source_outscale_api_access_rule_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"

--- a/outscale/data_source_outscale_api_access_rules.go
+++ b/outscale/data_source_outscale_api_access_rules.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func dataSourceOutscaleOAPIApiAccessRules() *schema.Resource {

--- a/outscale/data_source_outscale_api_access_rules_test.go
+++ b/outscale/data_source_outscale_api_access_rules_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"

--- a/outscale/data_source_outscale_ca.go
+++ b/outscale/data_source_outscale_ca.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func dataSourceOutscaleOAPICa() *schema.Resource {

--- a/outscale/data_source_outscale_ca_test.go
+++ b/outscale/data_source_outscale_ca_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func TestAccOthers_DataOutscaleCa_basic(t *testing.T) {

--- a/outscale/data_source_outscale_cas.go
+++ b/outscale/data_source_outscale_cas.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func dataSourceOutscaleOAPICas() *schema.Resource {

--- a/outscale/data_source_outscale_cas_test.go
+++ b/outscale/data_source_outscale_cas_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func TestAccOthers_DataOutscaleCas_basic(t *testing.T) {

--- a/outscale/data_source_outscale_client_gateway.go
+++ b/outscale/data_source_outscale_client_gateway.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func dataSourceOutscaleClientGateway() *schema.Resource {

--- a/outscale/data_source_outscale_client_gateway_test.go
+++ b/outscale/data_source_outscale_client_gateway_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func TestAccOthers_GatewayDatasource_basic(t *testing.T) {

--- a/outscale/data_source_outscale_client_gateways.go
+++ b/outscale/data_source_outscale_client_gateways.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func dataSourceOutscaleClientGateways() *schema.Resource {

--- a/outscale/data_source_outscale_dhcp_option.go
+++ b/outscale/data_source_outscale_dhcp_option.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func dataSourceOutscaleDHCPOption() *schema.Resource {

--- a/outscale/data_source_outscale_dhcp_options.go
+++ b/outscale/data_source_outscale_dhcp_options.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func dataSourceOutscaleDHCPOptions() *schema.Resource {

--- a/outscale/data_source_outscale_flexible_gpu.go
+++ b/outscale/data_source_outscale_flexible_gpu.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/outscale/terraform-provider-outscale/utils"
 	"github.com/spf13/cast"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
 )
 
 func dataSourceOutscaleOAPIFlexibleGpu() *schema.Resource {

--- a/outscale/data_source_outscale_flexible_gpu_catalog.go
+++ b/outscale/data_source_outscale_flexible_gpu_catalog.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func dataSourceOutscaleOAPIFlexibleGpuCatalog() *schema.Resource {

--- a/outscale/data_source_outscale_flexible_gpu_test.go
+++ b/outscale/data_source_outscale_flexible_gpu_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func TestAccOthers_DataSourceFlexibleGpu_basic(t *testing.T) {

--- a/outscale/data_source_outscale_flexible_gpus.go
+++ b/outscale/data_source_outscale_flexible_gpus.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func dataSourceOutscaleOAPIFlexibleGpus() *schema.Resource {

--- a/outscale/data_source_outscale_flexible_gpus_test.go
+++ b/outscale/data_source_outscale_flexible_gpus_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func TestAccOthers_DataSourceFlexibleGpus_basic(t *testing.T) {

--- a/outscale/data_source_outscale_image.go
+++ b/outscale/data_source_outscale_image.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func dataSourceOutscaleOAPIImage() *schema.Resource {

--- a/outscale/data_source_outscale_image_export_task.go
+++ b/outscale/data_source_outscale_image_export_task.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func dataSourceOutscaleOAPIImageExportTask() *schema.Resource {

--- a/outscale/data_source_outscale_image_export_task_test.go
+++ b/outscale/data_source_outscale_image_export_task_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )

--- a/outscale/data_source_outscale_image_export_tasks.go
+++ b/outscale/data_source_outscale_image_export_tasks.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func dataSourceOutscaleOAPIImageExportTasks() *schema.Resource {

--- a/outscale/data_source_outscale_image_export_tasks_test.go
+++ b/outscale/data_source_outscale_image_export_tasks_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )

--- a/outscale/data_source_outscale_image_test.go
+++ b/outscale/data_source_outscale_image_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func TestAccVM_WithImageDataSource_basic(t *testing.T) {

--- a/outscale/data_source_outscale_images.go
+++ b/outscale/data_source_outscale_images.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func dataSourceOutscaleOAPIImages() *schema.Resource {

--- a/outscale/data_source_outscale_images_test.go
+++ b/outscale/data_source_outscale_images_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func TestAccVM_WithImagesDataSource_basic(t *testing.T) {

--- a/outscale/data_source_outscale_internet_service.go
+++ b/outscale/data_source_outscale_internet_service.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/outscale/data_source_outscale_internet_services.go
+++ b/outscale/data_source_outscale_internet_services.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func datasourceOutscaleOAPIInternetServices() *schema.Resource {

--- a/outscale/data_source_outscale_keypair.go
+++ b/outscale/data_source_outscale_keypair.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func datasourceOutscaleOApiKeyPairRead(d *schema.ResourceData, meta interface{}) error {

--- a/outscale/data_source_outscale_keypair_test.go
+++ b/outscale/data_source_outscale_keypair_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func TestAccOthers_KeypairDataSource_Instance(t *testing.T) {

--- a/outscale/data_source_outscale_keypairs.go
+++ b/outscale/data_source_outscale_keypairs.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func datasourceOutscaleOAPiKeyPairsRead(d *schema.ResourceData, meta interface{}) error {

--- a/outscale/data_source_outscale_keypairs_test.go
+++ b/outscale/data_source_outscale_keypairs_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func TestAccOthers_KeypairsDataSource_Instance(t *testing.T) {

--- a/outscale/data_source_outscale_load_balancer.go
+++ b/outscale/data_source_outscale_load_balancer.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func attrLBchema() map[string]*schema.Schema {

--- a/outscale/data_source_outscale_load_balancer_listener_rule.go
+++ b/outscale/data_source_outscale_load_balancer_listener_rule.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func attrLBListenerRule() map[string]*schema.Schema {

--- a/outscale/data_source_outscale_load_balancer_listener_rules.go
+++ b/outscale/data_source_outscale_load_balancer_listener_rules.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func attrLBListenerRules() map[string]*schema.Schema {

--- a/outscale/data_source_outscale_load_balancer_tags.go
+++ b/outscale/data_source_outscale_load_balancer_tags.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func dataSourceOutscaleOAPILBUTags() *schema.Resource {

--- a/outscale/data_source_outscale_load_balancer_tags_test.go
+++ b/outscale/data_source_outscale_load_balancer_tags_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func TestAccOutscaleOAPIDSLoadBalancerTags_basic(t *testing.T) {

--- a/outscale/data_source_outscale_load_balancer_test.go
+++ b/outscale/data_source_outscale_load_balancer_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )

--- a/outscale/data_source_outscale_load_balancer_vm_health.go
+++ b/outscale/data_source_outscale_load_balancer_vm_health.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func dataSourceOutscaleLoadBalancerVmsHeals() *schema.Resource {

--- a/outscale/data_source_outscale_load_balancer_vms.go
+++ b/outscale/data_source_outscale_load_balancer_vms.go
@@ -2,7 +2,7 @@ package outscale
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func dataSourceOutscaleLoadBalancerVms() *schema.Resource {

--- a/outscale/data_source_outscale_load_balancers.go
+++ b/outscale/data_source_outscale_load_balancers.go
@@ -3,7 +3,7 @@ package outscale
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func attrLBSchema() map[string]*schema.Schema {

--- a/outscale/data_source_outscale_load_balancers_test.go
+++ b/outscale/data_source_outscale_load_balancers_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func TestAccOthers_LBUs_basic(t *testing.T) {

--- a/outscale/data_source_outscale_nat_service.go
+++ b/outscale/data_source_outscale_nat_service.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func dataSourceOutscaleOAPINatService() *schema.Resource {

--- a/outscale/data_source_outscale_nat_services.go
+++ b/outscale/data_source_outscale_nat_services.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func dataSourceOutscaleOAPINatServices() *schema.Resource {

--- a/outscale/data_source_outscale_net.go
+++ b/outscale/data_source_outscale_net.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func dataSourceOutscaleOAPIVpc() *schema.Resource {

--- a/outscale/data_source_outscale_net_access_point.go
+++ b/outscale/data_source_outscale_net_access_point.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func napdSchema() map[string]*schema.Schema {

--- a/outscale/data_source_outscale_net_access_point_services.go
+++ b/outscale/data_source_outscale_net_access_point_services.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func dataSourceOutscaleOAPINetAccessPointServices() *schema.Resource {

--- a/outscale/data_source_outscale_net_access_point_services_test.go
+++ b/outscale/data_source_outscale_net_access_point_services_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func TestAccNet_AccessPointServicesDataSource_basic(t *testing.T) {

--- a/outscale/data_source_outscale_net_access_point_test.go
+++ b/outscale/data_source_outscale_net_access_point_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func TestAccNet_AccessPointDataSource_basic(t *testing.T) {

--- a/outscale/data_source_outscale_net_access_points.go
+++ b/outscale/data_source_outscale_net_access_points.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func napSchema() map[string]*schema.Schema {

--- a/outscale/data_source_outscale_net_access_points_test.go
+++ b/outscale/data_source_outscale_net_access_points_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func TestAccNet_AccessPointsDataSource_basic(t *testing.T) {

--- a/outscale/data_source_outscale_net_attributes.go
+++ b/outscale/data_source_outscale_net_attributes.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/outscale/data_source_outscale_net_peering.go
+++ b/outscale/data_source_outscale_net_peering.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/outscale/data_source_outscale_net_peerings.go
+++ b/outscale/data_source_outscale_net_peerings.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/outscale/data_source_outscale_net_test.go
+++ b/outscale/data_source_outscale_net_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func TestAccNet_DataSource_basic(t *testing.T) {

--- a/outscale/data_source_outscale_nets.go
+++ b/outscale/data_source_outscale_nets.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func dataSourceOutscaleOAPIVpcs() *schema.Resource {

--- a/outscale/data_source_outscale_nets_test.go
+++ b/outscale/data_source_outscale_nets_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func TestAccNets_DataSource_basic(t *testing.T) {

--- a/outscale/data_source_outscale_nic.go
+++ b/outscale/data_source_outscale_nic.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/outscale/terraform-provider-outscale/utils"
 	"github.com/spf13/cast"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
 )
 
 // Creates a network interface in the specified subnet

--- a/outscale/data_source_outscale_nic_test.go
+++ b/outscale/data_source_outscale_nic_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"testing"
 	"time"

--- a/outscale/data_source_outscale_nics.go
+++ b/outscale/data_source_outscale_nics.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 // Creates a network interface in the specified subnet

--- a/outscale/data_source_outscale_nics_test.go
+++ b/outscale/data_source_outscale_nics_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func TestAccNet_WithNicsDataSource(t *testing.T) {

--- a/outscale/data_source_outscale_product_type.go
+++ b/outscale/data_source_outscale_product_type.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func dataSourceOutscaleOAPIProductType() *schema.Resource {

--- a/outscale/data_source_outscale_product_types.go
+++ b/outscale/data_source_outscale_product_types.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func dataSourceOutscaleOAPIProductTypes() *schema.Resource {

--- a/outscale/data_source_outscale_public_catalog.go
+++ b/outscale/data_source_outscale_public_catalog.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func dataSourceOutscaleOAPIPublicCatalog() *schema.Resource {

--- a/outscale/data_source_outscale_public_ip.go
+++ b/outscale/data_source_outscale_public_ip.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func dataSourceOutscaleOAPIPublicIP() *schema.Resource {

--- a/outscale/data_source_outscale_public_ip_test.go
+++ b/outscale/data_source_outscale_public_ip_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func TestAccOthers_DataSourcePublicIP(t *testing.T) {

--- a/outscale/data_source_outscale_public_ips.go
+++ b/outscale/data_source_outscale_public_ips.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func dataSourceOutscaleOAPIPublicIPS() *schema.Resource {

--- a/outscale/data_source_outscale_quota.go
+++ b/outscale/data_source_outscale_quota.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func dataSourceOutscaleOAPIQuota() *schema.Resource {

--- a/outscale/data_source_outscale_quotas.go
+++ b/outscale/data_source_outscale_quotas.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func dataSourceOutscaleOAPIQuotas() *schema.Resource {

--- a/outscale/data_source_outscale_regions.go
+++ b/outscale/data_source_outscale_regions.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func dataSourceOutscaleOAPIRegions() *schema.Resource {

--- a/outscale/data_source_outscale_route_table.go
+++ b/outscale/data_source_outscale_route_table.go
@@ -6,8 +6,8 @@ import (
 	"log"
 	"time"
 
+	"github.com/outscale/terraform-provider-outscale/utils"
 	"github.com/spf13/cast"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
 

--- a/outscale/data_source_outscale_route_tables.go
+++ b/outscale/data_source_outscale_route_tables.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func dataSourceOutscaleOAPIRouteTables() *schema.Resource {

--- a/outscale/data_source_outscale_security_group.go
+++ b/outscale/data_source_outscale_security_group.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func dataSourceOutscaleOAPISecurityGroup() *schema.Resource {

--- a/outscale/data_source_outscale_security_groups.go
+++ b/outscale/data_source_outscale_security_groups.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func dataSourceOutscaleOAPISecurityGroups() *schema.Resource {

--- a/outscale/data_source_outscale_server_certificate.go
+++ b/outscale/data_source_outscale_server_certificate.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func datasourceOutscaleOAPIServerCertificate() *schema.Resource {

--- a/outscale/data_source_outscale_server_certificates.go
+++ b/outscale/data_source_outscale_server_certificates.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func datasourceOutscaleOAPIServerCertificates() *schema.Resource {

--- a/outscale/data_source_outscale_snapshot.go
+++ b/outscale/data_source_outscale_snapshot.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func dataSourceOutscaleOAPISnapshot() *schema.Resource {

--- a/outscale/data_source_outscale_snapshot_export_task.go
+++ b/outscale/data_source_outscale_snapshot_export_task.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func dataSourceOutscaleOAPISnapshotExportTask() *schema.Resource {

--- a/outscale/data_source_outscale_snapshot_export_task_test.go
+++ b/outscale/data_source_outscale_snapshot_export_task_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/outscale/data_source_outscale_snapshot_export_tasks.go
+++ b/outscale/data_source_outscale_snapshot_export_tasks.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func dataSourceOutscaleOAPISnapshotExportTasks() *schema.Resource {

--- a/outscale/data_source_outscale_snapshot_export_tasks_test.go
+++ b/outscale/data_source_outscale_snapshot_export_tasks_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func TestAccOthers_SnapshotExportTasksDataSource_basic(t *testing.T) {

--- a/outscale/data_source_outscale_snapshot_test.go
+++ b/outscale/data_source_outscale_snapshot_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func TestAccOthers_SnapshotDataSource_basic(t *testing.T) {

--- a/outscale/data_source_outscale_snapshots.go
+++ b/outscale/data_source_outscale_snapshots.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func dataSourceOutscaleOAPISnapshots() *schema.Resource {

--- a/outscale/data_source_outscale_snapshots_test.go
+++ b/outscale/data_source_outscale_snapshots_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func TestAccOthers_SnapshotsDataSource_basic(t *testing.T) {

--- a/outscale/data_source_outscale_subnet.go
+++ b/outscale/data_source_outscale_subnet.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func dataSourceOutscaleOAPISubnet() *schema.Resource {

--- a/outscale/data_source_outscale_subnet_test.go
+++ b/outscale/data_source_outscale_subnet_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func TestAccNet_WithSubnet_DataSource(t *testing.T) {

--- a/outscale/data_source_outscale_subnets.go
+++ b/outscale/data_source_outscale_subnets.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func dataSourceOutscaleOAPISubnets() *schema.Resource {

--- a/outscale/data_source_outscale_subnets_test.go
+++ b/outscale/data_source_outscale_subnets_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func TestAccNet_WithSubnetsDataSource(t *testing.T) {

--- a/outscale/data_source_outscale_subregions.go
+++ b/outscale/data_source_outscale_subregions.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func dataSourceOutscaleOAPISubregions() *schema.Resource {

--- a/outscale/data_source_outscale_subregions_test.go
+++ b/outscale/data_source_outscale_subregions_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func TestAccOthers_SubregionsDataSource_Basic(t *testing.T) {

--- a/outscale/data_source_outscale_tag.go
+++ b/outscale/data_source_outscale_tag.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func dataSourceOutscaleOAPITag() *schema.Resource {

--- a/outscale/data_source_outscale_tags.go
+++ b/outscale/data_source_outscale_tags.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func dataSourceOutscaleOAPITags() *schema.Resource {

--- a/outscale/data_source_outscale_virtual_gateway.go
+++ b/outscale/data_source_outscale_virtual_gateway.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/outscale/data_source_outscale_virtual_gateways.go
+++ b/outscale/data_source_outscale_virtual_gateways.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/outscale/data_source_outscale_vm.go
+++ b/outscale/data_source_outscale_vm.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func dataSourceOutscaleOAPIVM() *schema.Resource {

--- a/outscale/data_source_outscale_vm_state.go
+++ b/outscale/data_source_outscale_vm_state.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func dataSourceOutscaleOAPIVMState() *schema.Resource {

--- a/outscale/data_source_outscale_vm_states.go
+++ b/outscale/data_source_outscale_vm_states.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func dataSourceOutscaleOAPIVMStates() *schema.Resource {

--- a/outscale/data_source_outscale_vm_test.go
+++ b/outscale/data_source_outscale_vm_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func TestAccVM_DataSource_basic(t *testing.T) {

--- a/outscale/data_source_outscale_vm_types.go
+++ b/outscale/data_source_outscale_vm_types.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	oscgo "github.com/outscale/osc-sdk-go/v2"
+	"github.com/outscale/terraform-provider-outscale/utils"
 	"github.com/spf13/cast"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
 )
 
 func dataSourceOutscaleOAPIVMTypes() *schema.Resource {

--- a/outscale/data_source_outscale_vms.go
+++ b/outscale/data_source_outscale_vms.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func datasourceOutscaleOApiVMS() *schema.Resource {

--- a/outscale/data_source_outscale_volume.go
+++ b/outscale/data_source_outscale_volume.go
@@ -12,7 +12,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func datasourceOutscaleOAPIVolume() *schema.Resource {

--- a/outscale/data_source_outscale_volume_test.go
+++ b/outscale/data_source_outscale_volume_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func TestAccOthers_VolumeDataSource_basic(t *testing.T) {

--- a/outscale/data_source_outscale_volumes.go
+++ b/outscale/data_source_outscale_volumes.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/outscale/data_source_outscale_volumes_test.go
+++ b/outscale/data_source_outscale_volumes_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func TestAccOthers_VolumesDataSource_multipleFilters(t *testing.T) {

--- a/outscale/data_source_outscale_vpn_connection.go
+++ b/outscale/data_source_outscale_vpn_connection.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
+	"github.com/outscale/terraform-provider-outscale/utils"
 	"github.com/spf13/cast"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/outscale/data_source_outscale_vpn_connection_test.go
+++ b/outscale/data_source_outscale_vpn_connection_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func TestAccOthers_VPNConnectionDataSource_basic(t *testing.T) {

--- a/outscale/data_source_outscale_vpn_connections.go
+++ b/outscale/data_source_outscale_vpn_connections.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func dataSourceOutscaleVPNConnections() *schema.Resource {

--- a/outscale/data_source_outscale_vpn_connections_test.go
+++ b/outscale/data_source_outscale_vpn_connections_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func TestAccOthers_VPNConnectionsDataSource_basic(t *testing.T) {

--- a/outscale/oapi_tags.go
+++ b/outscale/oapi_tags.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func setOSCAPITags(conn *oscgo.APIClient, d *schema.ResourceData) error {

--- a/outscale/resource_outscale_access_key.go
+++ b/outscale/resource_outscale_access_key.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/nav-inc/datetime"
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func resourceOutscaleAccessKey() *schema.Resource {

--- a/outscale/resource_outscale_access_key_test.go
+++ b/outscale/resource_outscale_access_key_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func TestAccOthers_AccessKey_basic(t *testing.T) {

--- a/outscale/resource_outscale_api_access_policy.go
+++ b/outscale/resource_outscale_api_access_policy.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func resourceOutscaleOAPIApiAccessPolicy() *schema.Resource {

--- a/outscale/resource_outscale_api_access_rule.go
+++ b/outscale/resource_outscale_api_access_rule.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	oscgo "github.com/outscale/osc-sdk-go/v2"
+	"github.com/outscale/terraform-provider-outscale/utils"
 	"github.com/spf13/cast"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
 )
 
 func resourceOutscaleOAPIApiAccessRule() *schema.Resource {

--- a/outscale/resource_outscale_api_access_rule_test.go
+++ b/outscale/resource_outscale_api_access_rule_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"

--- a/outscale/resource_outscale_ca.go
+++ b/outscale/resource_outscale_ca.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/openlyinc/pointy"
 	oscgo "github.com/outscale/osc-sdk-go/v2"
+	"github.com/outscale/terraform-provider-outscale/utils"
 	"github.com/spf13/cast"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
 )
 
 func resourceOutscaleOAPICa() *schema.Resource {

--- a/outscale/resource_outscale_ca_test.go
+++ b/outscale/resource_outscale_ca_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"

--- a/outscale/resource_outscale_client_gateway.go
+++ b/outscale/resource_outscale_client_gateway.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/outscale/terraform-provider-outscale/utils"
 	"github.com/spf13/cast"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/outscale/resource_outscale_client_gateway_test.go
+++ b/outscale/resource_outscale_client_gateway_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	oscgo "github.com/outscale/osc-sdk-go/v2"
+	"github.com/outscale/terraform-provider-outscale/utils"
 	"github.com/spf13/cast"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
 )
 
 func TestAccOthers_ClientGateway_basic(t *testing.T) {

--- a/outscale/resource_outscale_dhcp_option.go
+++ b/outscale/resource_outscale_dhcp_option.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/outscale/resource_outscale_dhcp_option_test.go
+++ b/outscale/resource_outscale_dhcp_option_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/openlyinc/pointy"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"

--- a/outscale/resource_outscale_flexible_gpu.go
+++ b/outscale/resource_outscale_flexible_gpu.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func resourceOutscaleOAPIFlexibleGpu() *schema.Resource {

--- a/outscale/resource_outscale_flexible_gpu_link.go
+++ b/outscale/resource_outscale_flexible_gpu_link.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func resourceOutscaleOAPIFlexibleGpuLink() *schema.Resource {

--- a/outscale/resource_outscale_flexible_gpu_link_test.go
+++ b/outscale/resource_outscale_flexible_gpu_link_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func TestAccVM_withFlexibleGpuLink_basic(t *testing.T) {

--- a/outscale/resource_outscale_flexible_gpu_test.go
+++ b/outscale/resource_outscale_flexible_gpu_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func TestAccOthers_FlexibleGpu_basic(t *testing.T) {

--- a/outscale/resource_outscale_image.go
+++ b/outscale/resource_outscale_image.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/outscale/resource_outscale_image_export_task.go
+++ b/outscale/resource_outscale_image_export_task.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/openlyinc/pointy"
 	oscgo "github.com/outscale/osc-sdk-go/v2"

--- a/outscale/resource_outscale_image_export_task_test.go
+++ b/outscale/resource_outscale_image_export_task_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"

--- a/outscale/resource_outscale_image_launch_permission.go
+++ b/outscale/resource_outscale_image_launch_permission.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/spf13/cast"
 

--- a/outscale/resource_outscale_image_launch_permission_test.go
+++ b/outscale/resource_outscale_image_launch_permission_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
 

--- a/outscale/resource_outscale_image_test.go
+++ b/outscale/resource_outscale_image_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/outscale/resource_outscale_internet_service.go
+++ b/outscale/resource_outscale_internet_service.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func resourceOutscaleOAPIInternetService() *schema.Resource {

--- a/outscale/resource_outscale_internet_service_link.go
+++ b/outscale/resource_outscale_internet_service_link.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/outscale/resource_outscale_internet_service_link_test.go
+++ b/outscale/resource_outscale_internet_service_link_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"

--- a/outscale/resource_outscale_internet_service_test.go
+++ b/outscale/resource_outscale_internet_service_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"

--- a/outscale/resource_outscale_keypair.go
+++ b/outscale/resource_outscale_keypair.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/outscale/resource_outscale_keypair_test.go
+++ b/outscale/resource_outscale_keypair_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/outscale/resource_outscale_load_balancer.go
+++ b/outscale/resource_outscale_load_balancer.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func lb_sg_schema() *schema.Schema {

--- a/outscale/resource_outscale_load_balancer_attributes.go
+++ b/outscale/resource_outscale_load_balancer_attributes.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/outscale/resource_outscale_load_balancer_attributes_test.go
+++ b/outscale/resource_outscale_load_balancer_attributes_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"

--- a/outscale/resource_outscale_load_balancer_listener_rule.go
+++ b/outscale/resource_outscale_load_balancer_listener_rule.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/outscale/resource_outscale_load_balancer_policy.go
+++ b/outscale/resource_outscale_load_balancer_policy.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
+	"github.com/outscale/terraform-provider-outscale/utils"
 	"github.com/spf13/cast"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/outscale/resource_outscale_load_balancer_policy_test.go
+++ b/outscale/resource_outscale_load_balancer_policy_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func TestAccOthers_CookieStickinessPolicy_basic(t *testing.T) {

--- a/outscale/resource_outscale_load_balancer_test.go
+++ b/outscale/resource_outscale_load_balancer_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"

--- a/outscale/resource_outscale_load_balancer_vms.go
+++ b/outscale/resource_outscale_load_balancer_vms.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/outscale/resource_outscale_load_balancer_vms_test.go
+++ b/outscale/resource_outscale_load_balancer_vms_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
 )

--- a/outscale/resource_outscale_nat_service.go
+++ b/outscale/resource_outscale_nat_service.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/outscale/resource_outscale_nat_service_test.go
+++ b/outscale/resource_outscale_nat_service_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"

--- a/outscale/resource_outscale_net.go
+++ b/outscale/resource_outscale_net.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/outscale/resource_outscale_net_access_point.go
+++ b/outscale/resource_outscale_net_access_point.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func resourceOutscaleNetAccessPoint() *schema.Resource {

--- a/outscale/resource_outscale_net_access_point_test.go
+++ b/outscale/resource_outscale_net_access_point_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func TestAccNet_AccessPoint_basic(t *testing.T) {

--- a/outscale/resource_outscale_net_attributes.go
+++ b/outscale/resource_outscale_net_attributes.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/outscale/resource_outscale_net_peering.go
+++ b/outscale/resource_outscale_net_peering.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/outscale/resource_outscale_net_peering_acceptation.go
+++ b/outscale/resource_outscale_net_peering_acceptation.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/outscale/resource_outscale_net_peering_test.go
+++ b/outscale/resource_outscale_net_peering_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"

--- a/outscale/resource_outscale_net_test.go
+++ b/outscale/resource_outscale_net_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"

--- a/outscale/resource_outscale_nic.go
+++ b/outscale/resource_outscale_nic.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/openlyinc/pointy"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 // Creates a network interface in the specified subnet

--- a/outscale/resource_outscale_nic_link.go
+++ b/outscale/resource_outscale_nic_link.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/outscale/resource_outscale_nic_link_test.go
+++ b/outscale/resource_outscale_nic_link_test.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
 

--- a/outscale/resource_outscale_nic_private_ip.go
+++ b/outscale/resource_outscale_nic_private_ip.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/outscale/resource_outscale_nic_private_ip_test.go
+++ b/outscale/resource_outscale_nic_private_ip_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )

--- a/outscale/resource_outscale_nic_test.go
+++ b/outscale/resource_outscale_nic_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"

--- a/outscale/resource_outscale_public_ip.go
+++ b/outscale/resource_outscale_public_ip.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func resourceOutscaleOAPIPublicIP() *schema.Resource {

--- a/outscale/resource_outscale_public_ip_link.go
+++ b/outscale/resource_outscale_public_ip_link.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/outscale/resource_outscale_public_ip_link_test.go
+++ b/outscale/resource_outscale_public_ip_link_test.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"

--- a/outscale/resource_outscale_public_ip_test.go
+++ b/outscale/resource_outscale_public_ip_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"

--- a/outscale/resource_outscale_route.go
+++ b/outscale/resource_outscale_route.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/openlyinc/pointy"
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/outscale/resource_outscale_route_table.go
+++ b/outscale/resource_outscale_route_table.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/outscale/resource_outscale_route_table_link.go
+++ b/outscale/resource_outscale_route_table_link.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/outscale/resource_outscale_route_table_link_test.go
+++ b/outscale/resource_outscale_route_table_link_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"

--- a/outscale/resource_outscale_route_table_test.go
+++ b/outscale/resource_outscale_route_table_test.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"

--- a/outscale/resource_outscale_security_group.go
+++ b/outscale/resource_outscale_security_group.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func resourceOutscaleOAPISecurityGroup() *schema.Resource {

--- a/outscale/resource_outscale_security_group_rule.go
+++ b/outscale/resource_outscale_security_group_rule.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/openlyinc/pointy"
 	oscgo "github.com/outscale/osc-sdk-go/v2"
+	"github.com/outscale/terraform-provider-outscale/utils"
 	"github.com/spf13/cast"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/outscale/resource_outscale_security_group_rule_test.go
+++ b/outscale/resource_outscale_security_group_rule_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/outscale/resource_outscale_server_certificate.go
+++ b/outscale/resource_outscale_server_certificate.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/openlyinc/pointy"
 	oscgo "github.com/outscale/osc-sdk-go/v2"
+	"github.com/outscale/terraform-provider-outscale/utils"
 	"github.com/spf13/cast"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
 )
 
 func resourceOutscaleOAPIServerCertificate() *schema.Resource {

--- a/outscale/resource_outscale_server_certificate_test.go
+++ b/outscale/resource_outscale_server_certificate_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/acctest"
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"

--- a/outscale/resource_outscale_snapshot.go
+++ b/outscale/resource_outscale_snapshot.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func resourceOutscaleOAPISnapshot() *schema.Resource {

--- a/outscale/resource_outscale_snapshot_attributes.go
+++ b/outscale/resource_outscale_snapshot_attributes.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/outscale/resource_outscale_snapshot_attributes_test.go
+++ b/outscale/resource_outscale_snapshot_attributes_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func TestAccOutscaleOAPISnapshotAttributes_Basic(t *testing.T) {

--- a/outscale/resource_outscale_snapshot_export_task.go
+++ b/outscale/resource_outscale_snapshot_export_task.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/openlyinc/pointy"
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/outscale/resource_outscale_snapshot_export_task_test.go
+++ b/outscale/resource_outscale_snapshot_export_task_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/hashicorp/terraform/helper/acctest"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func TestAccOthers_SnapshotExportTask_basic(t *testing.T) {

--- a/outscale/resource_outscale_snapshot_test.go
+++ b/outscale/resource_outscale_snapshot_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"

--- a/outscale/resource_outscale_subnet.go
+++ b/outscale/resource_outscale_subnet.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func resourceOutscaleOAPISubNet() *schema.Resource {

--- a/outscale/resource_outscale_subnet_test.go
+++ b/outscale/resource_outscale_subnet_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 )
 
 func TestAccNet_WithSubNet_basic(t *testing.T) {

--- a/outscale/resource_outscale_tags.go
+++ b/outscale/resource_outscale_tags.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/outscale/resource_outscale_tags_test.go
+++ b/outscale/resource_outscale_tags_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/go-test/deep"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
 

--- a/outscale/resource_outscale_virtual_gateway.go
+++ b/outscale/resource_outscale_virtual_gateway.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/outscale/resource_outscale_virtual_gateway_link.go
+++ b/outscale/resource_outscale_virtual_gateway_link.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/outscale/resource_outscale_virtual_gateway_link_test.go
+++ b/outscale/resource_outscale_virtual_gateway_link_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"

--- a/outscale/resource_outscale_virtual_gateway_route_propagation.go
+++ b/outscale/resource_outscale_virtual_gateway_route_propagation.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/outscale/resource_outscale_virtual_gateway_route_propagation_test.go
+++ b/outscale/resource_outscale_virtual_gateway_route_propagation_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"

--- a/outscale/resource_outscale_virtual_gateway_test.go
+++ b/outscale/resource_outscale_virtual_gateway_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"

--- a/outscale/resource_outscale_vm.go
+++ b/outscale/resource_outscale_vm.go
@@ -14,8 +14,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
+	"github.com/outscale/terraform-provider-outscale/utils"
 	"github.com/spf13/cast"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
 )
 
 func resourceOutscaleOApiVM() *schema.Resource {

--- a/outscale/resource_outscale_vm_test.go
+++ b/outscale/resource_outscale_vm_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/outscale/resource_outscale_volume.go
+++ b/outscale/resource_outscale_volume.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/outscale/resource_outscale_volume_test.go
+++ b/outscale/resource_outscale_volume_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"

--- a/outscale/resource_outscale_volumes_link.go
+++ b/outscale/resource_outscale_volumes_link.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/openlyinc/pointy"
 	oscgo "github.com/outscale/osc-sdk-go/v2"
+	"github.com/outscale/terraform-provider-outscale/utils"
 	"github.com/spf13/cast"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/outscale/resource_outscale_volumes_link_test.go
+++ b/outscale/resource_outscale_volumes_link_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"

--- a/outscale/resource_outscale_vpn_connection.go
+++ b/outscale/resource_outscale_vpn_connection.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/outscale/terraform-provider-outscale/utils"
 	"github.com/spf13/cast"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
 )

--- a/outscale/resource_outscale_vpn_connection_route.go
+++ b/outscale/resource_outscale_vpn_connection_route.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
 )

--- a/outscale/resource_outscale_vpn_connection_route_test.go
+++ b/outscale/resource_outscale_vpn_connection_route_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"

--- a/outscale/resource_outscale_vpn_connection_test.go
+++ b/outscale/resource_outscale_vpn_connection_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
-	"github.com/terraform-providers/terraform-provider-outscale/utils"
+	"github.com/outscale/terraform-provider-outscale/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/scripts/changelog-links.sh
+++ b/scripts/changelog-links.sh
@@ -24,7 +24,7 @@ else
   SED="sed -i.bak -r -e"
 fi
 
-PROVIDER_URL="https:\/\/github.com\/terraform-providers\/terraform-provider-aws\/issues"
+PROVIDER_URL="https:\/\/github.com\/outscale\/terraform-provider-aws\/issues"
 
 $SED "s/GH-([0-9]+)/\[#\1\]\($PROVIDER_URL\/\1\)/g" -e 's/\[\[#(.+)([0-9])\)]$/(\[#\1\2))/g' CHANGELOG.md
 


### PR DESCRIPTION
The module name was terraform-providers, but it was not downloadable, as a go mod.
This change the mod path, to its real path, so it's usable as a go module.