### PR TITLE
Graceful inconsistency management when public_ips in resourceOAPINatServiceRead() is empty

### DIFF
--- a/outscale/resource_outscale_nat_service.go
+++ b/outscale/resource_outscale_nat_service.go
@@ -178,8 +178,14 @@ func resourceOAPINatServiceRead(d *schema.ResourceData, meta interface{}) error 
 			return err
 		}
 
-		if err := set("public_ip_id", public_ips[0].GetPublicIpId()); err != nil {
-			return err
+		if len(public_ips) > 0 {
+			if err := set("public_ip_id", public_ips[0].GetPublicIpId()); err != nil {
+				return err
+			}
+		} else {
+			if err := set("public_ip_id", ""); err != nil {
+				return err
+			}
 		}
 
 		if err := d.Set("tags", tagsOSCAPIToMap(natService.GetTags())); err != nil {


### PR DESCRIPTION
Allow graceful inconsistency management by TF when `public_ips` in `resourceOAPINatServiceRead()` is empty

In `resourceOAPINatServiceRead()`, access to `public_ips[0]` isn't protected against empty list when the API can return an empty list in some edge cases. When `public_ips` is empty, setting `public_ip_id` to `""` allows the TF refresh to succeed and the TF plan/apply to recreate the Nat Service with the correct `public_ip_id`.

When the outscale_public_ip used by an outscale_nat_service is deleted, a refresh/plan crashes with the following error:
```
Stack trace from the terraform-provider-outscale_v0.9.1 plugin:

panic: runtime error: index out of range [0] with length 0

goroutine 195 [running]:
github.com/terraform-providers/terraform-provider-outscale/outscale.resourceOAPINatServiceRead.func1(0xc000a4cad0)
        github.com/terraform-providers/terraform-provider-outscale/outscale/resource_outscale_nat_service.go:182 +0x6f7
github.com/terraform-providers/terraform-provider-outscale/outscale.resourceDataAttrSetter(0xc0002d6f50, 0xc000a998d8)
        github.com/terraform-providers/terraform-provider-outscale/outscale/resource_outscale_vm.go:1334 +0x62
github.com/terraform-providers/terraform-provider-outscale/outscale.resourceOAPINatServiceRead(0xc0002d6f50, {0xff0d80?, 0xc0007b8d58?})
        github.com/terraform-providers/terraform-provider-outscale/outscale/resource_outscale_nat_service.go:161 +0x567
github.com/hashicorp/terraform-plugin-sdk/helper/schema.(*Resource).RefreshWithoutUpgrade(0xc0003828c0, 0xc000746a50, {0xff0d80, 0xc0007b8d58})
        github.com/hashicorp/terraform-plugin-sdk@v1.17.2/helper/schema/resource.go:470 +0x1aa
github.com/hashicorp/terraform-plugin-sdk/internal/helper/plugin.(*GRPCProviderServer).ReadResource(0xc000012068, {0xc000800a20?, 0x4bf046?}, 0xc000800a20)
        github.com/hashicorp/terraform-plugin-sdk@v1.17.2/internal/helper/plugin/grpc_provider.go:535 +0x365
github.com/hashicorp/terraform-plugin-sdk/internal/tfplugin5._Provider_ReadResource_Handler({0x11a9ee0?, 0xc000012068}, {0x14f63d8, 0xc000b2da70}, 0xc0008009c0, 0x0)
        github.com/hashicorp/terraform-plugin-sdk@v1.17.2/internal/tfplugin5/tfplugin5.pb.go:3269 +0x170
google.golang.org/grpc.(*Server).processUnaryRPC(0xc0001de380, {0x14faae0, 0xc000002000}, 0xc000696300, 0xc0006225a0, 0x1d1d8f0, 0x0)
        google.golang.org/grpc@v1.32.0/server.go:1194 +0xcbe
google.golang.org/grpc.(*Server).handleStream(0xc0001de380, {0x14faae0, 0xc000002000}, 0xc000696300, 0x0)
        google.golang.org/grpc@v1.32.0/server.go:1517 +0xa36
google.golang.org/grpc.(*Server).serveStreams.func1.2()
        google.golang.org/grpc@v1.32.0/server.go:859 +0x98
created by google.golang.org/grpc.(*Server).serveStreams.func1
        google.golang.org/grpc@v1.32.0/server.go:857 +0x28a

Error: The terraform-provider-outscale_v0.9.1 plugin crashed!
```