### PR TITLE
Allow graceful inconsistency management by TF when public_ips in reso…

### DIFF
--- a/outscale/resource_outscale_nat_service.go
+++ b/outscale/resource_outscale_nat_service.go
@@ -178,8 +178,14 @@ func resourceOAPINatServiceRead(d *schema.ResourceData, meta interface{}) error 
 			return err
 		}
 
-		if err := set("public_ip_id", public_ips[0].GetPublicIpId()); err != nil {
-			return err
+		if len(public_ips) > 0 {
+			if err := set("public_ip_id", public_ips[0].GetPublicIpId()); err != nil {
+				return err
+			}
+		} else {
+			if err := set("public_ip_id", ""); err != nil {
+				return err
+			}
 		}
 
 		if err := d.Set("tags", tagsOSCAPIToMap(natService.GetTags())); err != nil {


### PR DESCRIPTION
…urceOAPINatServiceRead() is empty

In `resourceOAPINatServiceRead()`, access to `public_ips[0]` isn't protected against empty list when the API can return an empty list in some edge cases. When `public_ips` is empty, setting `public_ip_id` to `""` allows the TF refresh to succeed and the TF plan/apply to recreate the Nat Service with the correct `public_ip_id`.