### PR TITLE
:bug: fix: net link resources replacement with unknown apply

### DIFF
--- a/outscale/resource_net.go
+++ b/outscale/resource_net.go
@@ -119,6 +119,9 @@ func (r *netResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp
 			},
 			"net_id": schema.StringAttribute{
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"state": schema.StringAttribute{
 				Computed: true,


### PR DESCRIPTION
- Fixes net dependencies being replaced when a resource has a net link (net peering, internet service)