### PR TITLE
📝 docs: Adding OKS kubeconfig Data Source

### DIFF
--- a/docs/data-sources/oks_kubeconfig.md
+++ b/docs/data-sources/oks_kubeconfig.md
@@ -1,14 +1,14 @@
 ---
 layout: "outscale"
 page_title: "OUTSCALE: outscale_oks_kubeconfig"
-sidebar_current: "outscale-oks_kubeconfig"
+sidebar_current: "outscale-oks-kubeconfig"
 description: |-
-  [Manages a kubeconfig file.]
+  [Provides information about a kubeconfig file.]
 ---
 
 # outscale_oks_kubeconfig Data Source
 
-Manages a kubeconfig file.
+Provides information about a kubeconfig file.
 
 For more information on this resource, see the [User Guide](https://docs.outscale.com/en/userguide/Accessing-a-Cluster.html).  
 For more information on this resource actions, see the [API documentation](https://docs.outscale.com/oks.html#getkubeconfigwithpubkeynacl).
@@ -25,7 +25,7 @@ data "outscale_oks_kubeconfig" "config" {
 
 The following arguments are supported:
 
-* `cluster_id` - The ID of the cluster.
+* `cluster_id` - (Required) The ID of the cluster.
 * `user` - (Optional) The user of the kubeconfig file.
 * `group` - (Optional) The group of the kubeconfig file.
 * `ttl` - (Optional) The time to live (TTL) of the kubeconfig file.


### PR DESCRIPTION
# 📦 Pull Request Template

## Description

To document:

outscale_oks_kubeconfig datasource
Corresponding OKS object: 

Resource: https://docs.outscale.com/oks.html#getkubeconfigwithpubkeynacl
Same arguments.

Exported attributes differs, the only exported attribute is :

`kubeconfig`

Example:

data "outscale_oks_kubeconfig" "config" {
  cluster_id = "00000000-0000-4000-8000-000000000000"
} 
 

This resource will go in the OKS service subcategory.

Fixes: #DOC-4807

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [X] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [ ] Manual testing
- [ ] Unit tests
- [X] Integration tests
- [ ] Not tested yet

## Checklist

* [ ] I have followed the [Contributing Guidelines](CONTRIBUTING.md)
* [ ] I have added tests or explained why they are not needed
* [ ] I have updated relevant documentation (README, examples, etc.)
* [ ] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [X] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
Preview
<img width="1133" height="836" alt="image" src="https://github.com/user-attachments/assets/9b60937b-c254-4540-9221-5bb95ff6c5be" />