### PR TITLE
✨ feat: Allow volume size updates without resource replacement

### DIFF
--- a/outscale/resource_volume_test.go
+++ b/outscale/resource_volume_test.go
@@ -39,6 +39,7 @@ func TestAccOthers_Volume_updateSize(t *testing.T) {
 	region := utils.GetRegion()
 
 	resourceName := "outscale_volume.accvolume"
+	var volumeID string
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: defineTestProviderFactoriesV6(),
@@ -48,6 +49,10 @@ func TestAccOthers_Volume_updateSize(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "size", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "tags.#"),
+					resource.TestCheckResourceAttrWith(resourceName, "volume_id", func(value string) error {
+						volumeID = value
+						return nil
+					}),
 				),
 			},
 			{
@@ -55,6 +60,12 @@ func TestAccOthers_Volume_updateSize(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "size", "10"),
 					resource.TestCheckResourceAttrSet(resourceName, "tags.#"),
+					resource.TestCheckResourceAttrWith(resourceName, "volume_id", func(value string) error {
+						if value != volumeID {
+							return fmt.Errorf("volume_id changed from %s to %s, resource was replaced instead of updated", volumeID, value)
+						}
+						return nil
+					}),
 				),
 			},
 		},


### PR DESCRIPTION
## Description

This PR adds support for updating volume size without requiring resource replacement. Previously, changing the `size` attribute would force Terraform to destroy and recreate the resource. Now it uses the Outscale API's `UpdateVolume` endpoint to modify the size in-place.

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [x] Manual testing
- [x] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

Commands used (if applicable):

```bash
# Unit tests passed
make test

# Linting passed
golangci-lint run --new-from-rev=$(git show-branch --merge-base origin/master)
```

## Checklist

* [x] I have followed the [Contributing Guidelines](CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [ ] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)