### PR TITLE
📝 docs: fixing indentation for tenancy subparameters

### DIFF
--- a/docs/resources/net.md
+++ b/docs/resources/net.md
@@ -77,7 +77,7 @@ The following arguments are supported:
 * `tags` - (Optional) A tag to add to this resource. You can specify this argument several times.
     * `key` - (Required) The key of the tag, with a minimum of 1 character.
     * `value` - (Required) The value of the tag, between 0 and 255 characters.
-* `tenancy` - (Optional) The tenancy options for the VMs:<br />- `default` if a VM created in a Net can be launched with any tenancy.<br />- `dedicated` if it can be launched with dedicated tenancy VMs running on single-tenant hardware.<br />- `dedicated group ID`: if it can be launched in a dedicated group on single-tenant hardware.
+* `tenancy` - (Optional) The tenancy options for the VMs:<br />- `default` if a VM created in a Net can be launched with any tenancy.<br />- `dedicated` if it can be launched with dedicated tenancy VMs running on single-tenant hardware.<br />- `dedicated group ID` if it can be launched in a dedicated group on single-tenant hardware.
 
 ## Attribute Reference
 


### PR DESCRIPTION
# 📦 Pull Request Template

## Description

"In this part of the documentation:
https://registry.terraform.io/providers/outscale/outscale/latest/docs/resources/net#tenancy-1 
The lines under “Tenancy” should be indented to the right."

Fixes: #<DOC-4922> 

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [x] Manual testing
- [ ] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

Commands used (if applicable):

```bash
# Example
my-cli-tool build --verbose
my-cli-tool test
````

## Checklist

* [ ] I have followed the [Contributing Guidelines](CONTRIBUTING.md)
* [ ] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [ ] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [X] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context

Add any additional context or screenshots if necessary.
