### PR TITLE
:bug: fix(security_group): optional name

### DIFF
--- a/outscale/resource_security_group_test.go
+++ b/outscale/resource_security_group_test.go
@@ -26,12 +26,29 @@ func TestAccNet_WithSecurityGroup(t *testing.T) {
 	})
 }
 
+func TestAccOthers_SecurityGroupWithoutName(t *testing.T) {
+	resourceName := "outscale_security_group.noname"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: DefineTestProviderFactoriesV6(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOutscaleSecurityGroupWithoutNameConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "security_group_name"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccNet_WithSecurityGroup_Migration(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() { testAccPreCheck(t) },
-		Steps:    FrameworkMigrationTestSteps("1.2.1", testAccOutscaleSecurityGroupConfig(rInt)),
+		Steps:    FrameworkMigrationTestSteps("1.2.1", testAccOutscaleSecurityGroupConfig(rInt), testAccOutscaleSecurityGroupWithoutNameConfig()),
 	})
 }
 
@@ -58,4 +75,17 @@ func testAccOutscaleSecurityGroupConfig(rInt int) string {
 			net_id = outscale_net.net.id
 		}
 	`, rInt)
+}
+
+func testAccOutscaleSecurityGroupWithoutNameConfig() string {
+	return fmt.Sprintf(`
+		resource "outscale_security_group" "noname" {
+			description         = "Used in the terraform acceptance tests"
+
+			tags {
+				key   = "Name"
+				value = "tf-acc-test-no-name"
+			}
+		}
+	`)
 }


### PR DESCRIPTION
## Description

- change required -> optional to security_group_name attribute to be backward compatible with
  SDKv2 implementation
- autogenerate the name if not specified

Related to #617

## Type of Change

Please check the relevant option(s):

- [X] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [X] Manual testing
- [ ] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [X] I have followed the [Contributing Guidelines](CONTRIBUTING.md)
* [X] I have added tests or explained why they are not needed
* [X] I have updated relevant documentation (README, examples, etc.)
* [X] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [X] My commits include appropriate [Gitmoji](https://gitmoji.dev/)
