### PR TITLE
📝 docs: marking the security_group_name argument as optional

### DIFF
--- a/docs/resources/security_group.md
+++ b/docs/resources/security_group.md
@@ -56,8 +56,8 @@ This description can contain between 1 and 255 characters. Allowed characters ar
 * `net_id` - (Optional) The ID of the Net for the security group.
 * `remove_default_outbound_rule` - (Optional) (Net only) By default or if set to false, the security group is created with a default outbound rule allowing all outbound flows. If set to true, the security group is created without a default outbound rule. For an existing security group, setting this parameter to true deletes the security group and creates a new one.
 * `security_group_name` - (Optional) A name for the security group.<br />
-This name must not start with `sg-`.<br />
-This name must be unique and contain between 1 and 255 characters. Allowed characters are `a-z`, `A-Z`, `0-9`, spaces, and `_.-:/()#,@[]+=&;{}!$*`.
+This name must be unique and contain between 1 and 255 characters. It must not start with `sg-`. Allowed characters are `a-z`, `A-Z`, `0-9`, spaces, and `_.-:/()#,@[]+=&;{}!$*`.<br />
+If not specified, the security group name is randomly generated.
 * `tags` - (Optional) A tag to add to this resource. You can specify this argument several times.
     * `key` - (Required) The key of the tag, with a minimum of 1 character.
     * `value` - (Required) The value of the tag, between 0 and 255 characters.


### PR DESCRIPTION
…p resource as optional

# 📦 Pull Request Template

## Description

The Terraform documentation for the [security_group](https://registry.terraform.io/providers/outscale/outscale/latest/docs/resources/security_group) resource specifies that the security_group_name attribute is required.

In the provider, the attribute is handled as optional and generates a random name if the attribute is not specified.

Could you update the documentation to reflect this behavior?

Fixes: 1.3.2 ([DOC-4982](https://jira.outscale.internal/browse/DOC-4982))

## Type of Change

Please check the relevant option(s):

- [X] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [X] Manual testing
- [ ] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [ ] I have followed the [Contributing Guidelines](CONTRIBUTING.md)
* [ ] I have added tests or explained why they are not needed
* [X] I have updated relevant documentation (README, examples, etc.)
* [ ] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [X] My commits include appropriate [Gitmoji](https://gitmoji.dev/)