### PR TITLE
:bug: fix: go-releaser argument deprecation

### DIFF
--- a/.github/workflows/generate_binaries_on_pr.yml
+++ b/.github/workflows/generate_binaries_on_pr.yml
@@ -5,6 +5,7 @@ on:
         branches:
             - master
         paths:
+            - ".github/workflows/generate_binaries_on_pr.yml"
             - "**.go"
             - "**.sum"
             - "**.mod"
@@ -27,7 +28,7 @@ jobs:
               uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
               with:
                   version: latest
-                  args: build --rm-dist --snapshot
+                  args: build --clean --snapshot
             - name: Upload assets
               uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
               with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,56 +1,59 @@
-# Visit https://goreleaser.com for documentation on how to customize this
-# behavior.
+version: 2
+
 before:
-  hooks:
-    # this is just an example and not a requirement for provider building/publishing
-    - go mod tidy
+    hooks:
+        - go mod tidy
+
 builds:
-- env:
-    # goreleaser does not work with CGO, it could also complicate
-    # usage by users in CI/CD systems like Terraform Cloud where
-    # they are unable to install libraries.
-    - CGO_ENABLED=0
-  mod_timestamp: '{{ .CommitTimestamp }}'
-  flags:
-    - -trimpath
-  ldflags:
-    - '-s -w -X {{ .ModulePath }}/version.version={{.Version}}'
-  goos:
-    - windows
-    - linux
-    - darwin
-  goarch:
-    - amd64
-    - '386'
-    - arm64
-  ignore:
-    - goos: windows
-      goarch: arm64
-    - goos: darwin
-      goarch: '386'
-    - goos: linux
-      goarch: '386'
-  binary: '{{ .ProjectName }}_v{{ .Version }}'
+    - env:
+          - CGO_ENABLED=0
+      goos:
+          - linux
+          - windows
+          - darwin
+      goarch:
+          - amd64
+          - "386"
+          - arm64
+      ignore:
+          - goos: windows
+            goarch: arm64
+          - goos: darwin
+            goarch: "386"
+          - goos: linux
+            goarch: "386"
+      mod_timestamp: "{{ .CommitTimestamp }}"
+      flags:
+          - -trimpath
+      ldflags:
+          - "-s -w -X {{ .ModulePath }}/version.version={{.Version}}"
+      binary: "{{ .ProjectName }}_v{{ .Version }}"
+
 archives:
-- format: zip
-  name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+    - formats: [tar.gz]
+      # this name template makes the OS and Arch compatible with the results of `uname`.
+      name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+      # use zip for windows archives
+      format_overrides:
+          - goos: windows
+            formats: [zip]
+
 checksum:
-  name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
-  algorithm: sha256
+    name_template: "{{ .ProjectName }}_{{ .Version }}_SHA256SUMS"
+    algorithm: sha256
 signs:
-  - artifacts: checksum
-    args:
-      # if you are using this is a GitHub action or some other automated pipeline, you 
-      # need to pass the batch flag to indicate its not interactive.
-      - "--batch"
-      - "--local-user"
-      - "{{ .Env.GPG_FINGERPRINT }}" # set this environment variable for your signing key
-      - "--output"
-      - "${signature}"
-      - "--detach-sign"
-      - "${artifact}"
-release:
-  # If you want to manually examine the release before its live, uncomment this line:
-    draft: true
+    - artifacts: checksum
+      args:
+          - "--batch"
+          - "--local-user"
+          - "{{ .Env.GPG_FINGERPRINT }}"
+          - "--output"
+          - "${signature}"
+          - "--detach-sign"
+          - "${artifact}"
+
 changelog:
-  use: github
+    use: github
+
+release:
+    draft: true


### PR DESCRIPTION
## Description

Bumped go-releaser to v6 deprecated the --rm-dist argument in favor or --clean

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [X] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [ ] Manual testing
- [ ] Unit tests
- [ ] Integration tests
- [X] Not tested yet

## Checklist

* [X] I have followed the [Contributing Guidelines](CONTRIBUTING.md)
* [X] I have added tests or explained why they are not needed
* [X] I have updated relevant documentation (README, examples, etc.)
* [X] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [X] My commits include appropriate [Gitmoji](https://gitmoji.dev/)
