### PR TITLE
📝 docs: Adding tpm_mandatory to the image arguments

### DIFF
--- a/docs/data-sources/image.md
+++ b/docs/data-sources/image.md
@@ -99,3 +99,4 @@ For more information about volume types, see [About Volumes > Volume Types and I
 * `tags` - One or more tags associated with the OMI.
     * `key` - The key of the tag, with a minimum of 1 character.
     * `value` - The value of the tag, between 0 and 255 characters.
+* `tpm_mandatory` - If true, a virtual Trusted Platform Module (vTPM) is mandatory for VMs created from this OMI. If false, a vTPM is not mandatory.

--- a/docs/data-sources/images.md
+++ b/docs/data-sources/images.md
@@ -104,3 +104,4 @@ For more information about volume types, see [About Volumes > Volume Types and I
     * `tags` - One or more tags associated with the OMI.
         * `key` - The key of the tag, with a minimum of 1 character.
         * `value` - The value of the tag, between 0 and 255 characters.
+    * `tpm_mandatory` - If true, a virtual Trusted Platform Module (vTPM) is mandatory for VMs created from this OMI. If false, a vTPM is not mandatory.

--- a/docs/resources/image.md
+++ b/docs/resources/image.md
@@ -98,6 +98,7 @@ Constraints: 3-128 alphanumeric characters, underscores (`_`), spaces (` `), par
 * `tags` - (Optional) A tag to add to this resource. You can specify this argument several times.
     * `key` - (Required) The key of the tag, with a minimum of 1 character.
     * `value` - (Required) The value of the tag, between 0 and 255 characters.
+* `tpm_mandatory` - (Optional) By default or if set to false, a virtual Trusted Platform Module (vTPM) is not mandatory on VMs created from this OMI. If true, VMs created from this OMI must have a vTPM enabled.
 * `vm_id` - (Optional) **(required) When creating from a VM:** The ID of the VM from which you want to create the OMI.
 
 ## Attribute Reference
@@ -142,6 +143,7 @@ For more information about volume types, see [About Volumes > Volume Types and I
 * `tags` - One or more tags associated with the OMI.
     * `key` - The key of the tag, with a minimum of 1 character.
     * `value` - The value of the tag, between 0 and 255 characters.
+* `tpm_mandatory` - If true, a virtual Trusted Platform Module (vTPM) is mandatory for VMs created from this OMI. If false, a vTPM is not mandatory.
 
 ## Import
 


### PR DESCRIPTION
# 📦 Pull Request Template

## Description

An argument/attribute was added to the outscale_image:  tpm_mandatory (optional), which is the TpmMandatory parameter of CreateImage

Fixes: #[DOC-5043](https://jira.outscale.internal/browse/DOC-5043)

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [X] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [X] Manual testing
- [ ] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

Commands used (if applicable):

```bash
# Example
my-cli-tool build --verbose
my-cli-tool test
````

## Checklist

* [ ] I have followed the [Contributing Guidelines](CONTRIBUTING.md)
* [ ] I have added tests or explained why they are not needed
* [X] I have updated relevant documentation (README, examples, etc.)
* [ ] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [X] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context

Add any additional context or screenshots if necessary.
