### PR TITLE
🐛 fix: per-service configuration

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -88,16 +88,12 @@ func NewOAPIClient(cfg Config) (*oscgo.APIClient, error) {
 
 func NewOKSClient(cfg Config) (*sdkv3_oks.Client, error) {
 	profile := sdkv3_profile.Profile{
-		AccessKey:      cfg.AccessKeyID,
-		SecretKey:      cfg.SecretKeyID,
-		Region:         cfg.Region,
-		X509ClientCert: cfg.X509CertPath,
-		X509ClientKey:  cfg.X509KeyPath,
-		TlsSkipVerify:  cfg.Insecure,
-		Protocol:       "https",
+		AccessKey: cfg.AccessKeyID,
+		SecretKey: cfg.SecretKeyID,
+		Region:    cfg.Region,
+		Protocol:  "https",
 		Endpoints: sdkv3_profile.Endpoint{
 			OKS: cfg.OKSEndpoint,
-			API: cfg.APIEndpoint,
 		},
 	}
 


### PR DESCRIPTION
## Description

Introduces `api` and `oks` configuration blocks to the provider, allowing per-service settings. The previous configuration is deprecated but still works as a fallback.

The following top-level attributes are deprecated and will be removed in the next major version:

| Deprecated attribute | Replacement |
|---|---|
| region | api { region = "..." } and oks { region = "..." } |
| endpoints { api = "..." } | api { endpoint = "..." } |
| endpoints { oks = "..." } | oks { endpoint = "..." } |
| x509_cert_path | api { x509_cert_path = "..." } |
| x509_key_path | api { x509_key_path = "..." } |
| insecure | api { insecure = true } |

Before:

```hcl
provider "outscale" {
  region         = "eu-west-2"
  x509_cert_path = "/path/to/cert.pem"
  x509_key_path  = "/path/to/key.pem"
  insecure       = false
  endpoints {
    api = "https://api.eu-west-2.outscale.com"
    oks = "https://api.eu-west-2.oks.outscale.com/api/v2"
  }
}
```

After:
```hcl
provider "outscale" {
  api {
    endpoint       = "https://api.eu-west-2.outscale.com"
    region         = "eu-west-2"
    x509_cert_path = "/path/to/cert.pem"
    x509_key_path  = "/path/to/key.pem"
  }
  oks {
    endpoint = "https://api.eu-west-2.oks.outscale.com/api/v2"
    region   = "eu-west-2"
  }
}
```

The `x509_cert_path`, `x509_key_path`, and `insecure` deprecated attributes are specific to the IaaS API and no longer apply to OKS.

Fixes: #679

## Type of Change

Please check the relevant option(s):

- [X] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [X] Manual testing
- [ ] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [X] I have followed the [Contributing Guidelines](CONTRIBUTING.md)
* [X] I have added tests or explained why they are not needed
* [X] I have updated relevant documentation (README, examples, etc.)
* [X] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [X] My commits include appropriate [Gitmoji](https://gitmoji.dev/)
