### PR TITLE
💚 ci(goreleaser): terraform expects zip package

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,44 +1,41 @@
+# Visit https://goreleaser.com for documentation on how to customize this
+# behavior.
 version: 2
-
 before:
     hooks:
         - go mod tidy
-
 builds:
     - env:
           - CGO_ENABLED=0
-      goos:
-          - linux
-          - windows
-          - darwin
-      goarch:
-          - amd64
-          - "386"
-          - arm64
-      ignore:
-          - goos: windows
-            goarch: arm64
-          - goos: darwin
-            goarch: "386"
-          - goos: linux
-            goarch: "386"
       mod_timestamp: "{{ .CommitTimestamp }}"
       flags:
           - -trimpath
       ldflags:
-          - "-s -w -X {{ .ModulePath }}/version.version={{.Version}}"
-      binary: "{{ .ProjectName }}_v{{ .Version }}"
-
-archives:
-    - formats: [tar.gz]
-      # this name template makes the OS and Arch compatible with the results of `uname`.
-      name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
-      # use zip for windows archives
-      format_overrides:
+          - "-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}"
+      goos:
+          - freebsd
+          - windows
+          - linux
+          - darwin
+      goarch:
+          - amd64
+          - "386"
+          - arm
+          - arm64
+      ignore:
+          - goos: darwin
+            goarch: "386"
           - goos: windows
-            formats: [zip]
-
+            goarch: arm
+      binary: "{{ .ProjectName }}_v{{ .Version }}"
+archives:
+    - formats:
+          - zip
+      name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 checksum:
+    extra_files:
+        - glob: "terraform-registry-manifest.json"
+          name_template: "{{ .ProjectName }}_{{ .Version }}_manifest.json"
     name_template: "{{ .ProjectName }}_{{ .Version }}_SHA256SUMS"
     algorithm: sha256
 signs:
@@ -46,14 +43,15 @@ signs:
       args:
           - "--batch"
           - "--local-user"
-          - "{{ .Env.GPG_FINGERPRINT }}"
+          - "{{ .Env.GPG_FINGERPRINT }}" # set this environment variable for your signing key
           - "--output"
           - "${signature}"
           - "--detach-sign"
           - "${artifact}"
-
-changelog:
-    use: github
-
 release:
+    extra_files:
+        - glob: "terraform-registry-manifest.json"
+          name_template: "{{ .ProjectName }}_{{ .Version }}_manifest.json"
     draft: true
+
+changelog: use:github


### PR DESCRIPTION
## Description

`.goreleaser.yml` was udpated following the goreleaser init template, which changed the packages extensions to a tar.gz package instead of a zip for linux builds. Terraform expects a zip package.
This PR fixes the file by following the scaffolding template: https://github.com/hashicorp/terraform-provider-scaffolding-framework/blob/main/.goreleaser.yml

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [X] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [ ] Manual testing
- [ ] Unit tests
- [ ] Integration tests
- [X] Not tested yet

## Checklist

* [X] I have followed the [Contributing Guidelines](CONTRIBUTING.md)
* [X] I have added tests or explained why they are not needed
* [X] I have updated relevant documentation (README, examples, etc.)
* [X] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [X] My commits include appropriate [Gitmoji](https://gitmoji.dev/)
