### PR TITLE
🐛 Ensure subprocess commands use string for Windows compatibility

### DIFF
--- a/tests/test_provider_base.py
+++ b/tests/test_provider_base.py
@@ -480,7 +480,7 @@ Log: {}
     def exec_test_step(self, tf_file_path, out_file_path, is_first_step=True):
         self.logger.debug("Exec step : {}".format(tf_file_path))
         self.log += "\nTerraform validate:\n{}".format(
-            self.run_cmd(["terraform validate -no-color"])[0]
+            self.run_cmd("terraform validate -no-color")[0]
         )
 
         plan_json_path = out_file_path.replace(".out", ".plan.json")
@@ -511,9 +511,9 @@ Log: {}
             self.run_cmd("terraform apply -auto-approve -lock=false -no-color")[0]
         )
         self.log += "\nTerraform show:\n{}".format(
-            self.run_cmd(["terraform show -no-color"])[0]
+            self.run_cmd("terraform show -no-color")[0]
         )
-        self.run_cmd(["terraform state pull > {}".format(out_file_path)])
+        self.run_cmd("terraform state pull > {}".format(out_file_path))
 
     def exec_test(self, test_name, test_path, tmp_path):
         self.work_dir = str(tmp_path)
@@ -540,8 +540,8 @@ Log: {}
         try:
             self.logger.debug("Start test: '%s' in %s", test_name, self.work_dir)
 
-            self.run_cmd(["terraform init -no-color"])
-            stdout, _ = self.run_cmd(["terraform version -no-color"])
+            self.run_cmd("terraform init -no-color")
+            stdout, _ = self.run_cmd("terraform version -no-color")
             self.log += "\nVERSION:{}\n".format("\n".join(stdout.splitlines()[:2]))
 
             tf_file_names = get_test_file_names(test_path, prefix="step", suffix=".tf")


### PR DESCRIPTION
## Description

This PR fixes Windows compatibility issues caused by incorrect usage of **subprocess.Popen** with **shell=True.**

Previously, some Terraform commands were passed as lists while shell=True was enabled. This behavior works inconsistently across environments and caused execution failures on Windows systems.

This change standardizes all subprocess command invocations to use string-based commands when shell=True is enabled, ensuring consistent behavior across platforms.

Fixes: N/A

Windows Terraform Test Execution Guide: 
[README_Windows_Test_Guide_Outscale.md](https://github.com/user-attachments/files/25542372/README_Windows_Test_Guide_Outscale.md)


## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

- [ ] Manual testing
- [ ] Unit tests
- [ ] Integration tests
- [x] Not tested yet

## Checklist

* [ ] I have followed the [Contributing Guidelines](CONTRIBUTING.md)
* [ ] I have added tests or explained why they are not needed
* [ ] I have updated relevant documentation (README, examples, etc.)
* [ ] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)