### PR TITLE
🐛 fix(timeouts): inconsistent apply after import

### DIFF
--- a/internal/services/oapi/resource_access_key.go
+++ b/internal/services/oapi/resource_access_key.go
@@ -313,6 +313,7 @@ func (r *resourceAccessKey) Update(ctx context.Context, req resource.UpdateReque
 		return
 	}
 
+	stateData.Timeouts = planData.Timeouts
 	err = setAccessKeyState(ctx, r, &stateData)
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/internal/services/oapi/resource_api_access_policy.go
+++ b/internal/services/oapi/resource_api_access_policy.go
@@ -200,6 +200,7 @@ func (r *resourceApiAccessPolicy) Update(ctx context.Context, req resource.Updat
 		)
 	}
 
+	stateData.Timeouts = planData.Timeouts
 	newStateData, err := r.read(ctx, timeout, stateData)
 	if err != nil {
 		if errors.Is(err, ErrResourceEmpty) {

--- a/internal/services/oapi/resource_api_access_rule.go
+++ b/internal/services/oapi/resource_api_access_rule.go
@@ -265,6 +265,7 @@ func (r *resourceApiAccessRule) Update(ctx context.Context, req resource.UpdateR
 		)
 	}
 
+	stateData.Timeouts = planData.Timeouts
 	newStateData, err := r.read(ctx, timeout, stateData)
 	if err != nil {
 		if errors.Is(err, ErrResourceEmpty) {

--- a/internal/services/oapi/resource_ca.go
+++ b/internal/services/oapi/resource_ca.go
@@ -204,6 +204,7 @@ func (r *resoureCa) Update(ctx context.Context, req resource.UpdateRequest, resp
 		)
 	}
 
+	stateData.Timeouts = planData.Timeouts
 	newStateData, err := r.read(ctx, timeout, stateData)
 	if err != nil {
 		if errors.Is(err, ErrResourceEmpty) {

--- a/internal/services/oapi/resource_keypair.go
+++ b/internal/services/oapi/resource_keypair.go
@@ -246,6 +246,7 @@ func (r *resourceKeypair) Update(ctx context.Context, req resource.UpdateRequest
 		return
 	}
 
+	stateData.Timeouts = planData.Timeouts
 	err := setKeypairState(ctx, r, &stateData)
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/internal/services/oapi/resource_net.go
+++ b/internal/services/oapi/resource_net.go
@@ -254,6 +254,7 @@ func (r *resourceNet) Update(ctx context.Context, req resource.UpdateRequest, re
 		return
 	}
 
+	stateData.Timeouts = planData.Timeouts
 	data, err := setNetState(ctx, r, stateData)
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/internal/services/oapi/resource_net_access_point.go
+++ b/internal/services/oapi/resource_net_access_point.go
@@ -300,6 +300,7 @@ func (r *resourceNetAccessPoint) Update(ctx context.Context, req resource.Update
 		}
 	}
 
+	stateData.Timeouts = planData.Timeouts
 	data, err := setNetAccessPointState(ctx, r, stateData)
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/internal/services/oapi/resource_net_peering.go
+++ b/internal/services/oapi/resource_net_peering.go
@@ -369,6 +369,7 @@ func (r *resourceNetPeering) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 
+	stateData.Timeouts = planData.Timeouts
 	data, err := r.read(ctx, stateData)
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/internal/services/oapi/resource_route.go
+++ b/internal/services/oapi/resource_route.go
@@ -433,6 +433,7 @@ func (r *resourceRoute) Update(ctx context.Context, req resource.UpdateRequest, 
 		}
 	}
 
+	stateData.Timeouts = planData.Timeouts
 	data, err := r.read(ctx, stateData)
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/internal/services/oapi/resource_route_table.go
+++ b/internal/services/oapi/resource_route_table.go
@@ -298,6 +298,7 @@ func (r *resourceRouteTable) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 
+	stateData.Timeouts = planData.Timeouts
 	data, err := r.read(ctx, stateData)
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/internal/services/oapi/resource_security_group.go
+++ b/internal/services/oapi/resource_security_group.go
@@ -404,6 +404,7 @@ func (r *resourceSecurityGroup) Update(ctx context.Context, req resource.UpdateR
 		return
 	}
 
+	stateData.Timeouts = planData.Timeouts
 	data, err := setSecurityGroupState(ctx, r, stateData)
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/internal/services/oapi/resource_subnet.go
+++ b/internal/services/oapi/resource_subnet.go
@@ -326,6 +326,7 @@ func (r *resourceSubnet) Update(ctx context.Context, req resource.UpdateRequest,
 		return
 	}
 
+	stateData.Timeouts = planData.Timeouts
 	data, err := r.read(ctx, stateData)
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/internal/services/oapi/resource_user.go
+++ b/internal/services/oapi/resource_user.go
@@ -305,6 +305,7 @@ func (r *resourceUser) Update(ctx context.Context, req resource.UpdateRequest, r
 		}
 	}
 
+	stateData.Timeouts = planData.Timeouts
 	newStateData, err := r.read(ctx, timeout, stateData)
 	if err != nil {
 		if errors.Is(err, ErrResourceEmpty) {

--- a/internal/services/oapi/resource_user_group.go
+++ b/internal/services/oapi/resource_user_group.go
@@ -331,6 +331,7 @@ func (r *resourceUserGroup) Update(ctx context.Context, req resource.UpdateReque
 		}
 	}
 
+	stateData.Timeouts = planData.Timeouts
 	newStateData, err := r.read(ctx, timeout, stateData)
 	if err != nil {
 		if errors.Is(err, ErrResourceEmpty) {

--- a/internal/services/oapi/resource_volume.go
+++ b/internal/services/oapi/resource_volume.go
@@ -415,6 +415,7 @@ func (r *resourceVolume) Update(ctx context.Context, req resource.UpdateRequest,
 		}
 	}
 
+	stateData.Timeouts = planData.Timeouts
 	err := setVolumeState(ctx, r, &stateData)
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/internal/services/oapi/resource_volume_link.go
+++ b/internal/services/oapi/resource_volume_link.go
@@ -269,6 +269,7 @@ func (r *resourceVolumeLink) Update(ctx context.Context, req resource.UpdateRequ
 	}
 	dataState.ForceUnlink = dataPlan.ForceUnlink
 
+	dataState.Timeouts = dataPlan.Timeouts
 	err := setLinkedVolumeState(ctx, r, &dataState)
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/internal/services/oks/resource_oks_cluster.go
+++ b/internal/services/oks/resource_oks_cluster.go
@@ -554,11 +554,7 @@ func (r *oksClusterResource) Create(ctx context.Context, req resource.CreateRequ
 	plan.RequestId = to.String(createResp.ResponseContext.RequestId)
 	plan.Id = to.String(createResp.Cluster.Id)
 
-	to, diag := plan.Timeouts.Create(ctx, CreateDefaultTimeout)
-	if fwhelpers.CheckDiags(resp, diag) {
-		return
-	}
-	data, err := r.read(ctx, plan, to)
+	data, err := r.read(ctx, plan, timeout)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to set Cluster state",
@@ -610,7 +606,7 @@ func (r *oksClusterResource) Update(ctx context.Context, req resource.UpdateRequ
 	if fwhelpers.CheckDiags(resp, diag) {
 		return
 	}
-	timeout, diag := plan.Timeouts.Read(ctx, ReadDefaultTimeout)
+	timeout, diag := plan.Timeouts.Update(ctx, UpdateDefaultTimeout)
 	if fwhelpers.CheckDiags(resp, diag) {
 		return
 	}
@@ -729,15 +725,17 @@ func (r *oksClusterResource) Update(ctx context.Context, req resource.UpdateRequ
 		updateReq.Tags = &tags
 	}
 
-	updateResp, err := r.Client.UpdateCluster(ctx, state.Id.ValueString(), updateReq, options.WithRetryTimeout(timeout))
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to Update Cluster",
-			"Error: "+err.Error(),
-		)
-		return
+	if updateReq != (oks.ClusterUpdate{}) {
+		updateResp, err := r.Client.UpdateCluster(ctx, state.Id.ValueString(), updateReq, options.WithRetryTimeout(timeout))
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Unable to Update Cluster",
+				"Error: "+err.Error(),
+			)
+			return
+		}
+		state.RequestId = to.String(updateResp.ResponseContext.RequestId)
 	}
-	state.RequestId = to.String(updateResp.ResponseContext.RequestId)
 
 	if doUpgrade {
 		_, err := r.waitForClusterState(ctx, state.Id.ValueString(), []string{"pending", "updating"}, []string{"ready"}, timeout)
@@ -747,7 +745,15 @@ func (r *oksClusterResource) Update(ctx context.Context, req resource.UpdateRequ
 			)
 			return
 		}
-		upgradeResp, err := r.Client.UpgradeCluster(ctx, state.Id.ValueString(), options.WithRetryTimeout(timeout))
+
+		// We either take the user-defined Update timeout, or the default upgrade timeout if not set
+		upgradeTimeout, diag := plan.Timeouts.Update(ctx, UpgradeDefaultTimeout)
+		if fwhelpers.CheckDiags(resp, diag) {
+			return
+		}
+		tflog.Info(ctx, fmt.Sprintf("Cluster upgrading. Timeout changed to %s.", upgradeTimeout.String()))
+
+		upgradeResp, err := r.Client.UpgradeCluster(ctx, state.Id.ValueString(), options.WithRetryTimeout(upgradeTimeout))
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Unable to Upgrade Cluster",
@@ -756,13 +762,8 @@ func (r *oksClusterResource) Update(ctx context.Context, req resource.UpdateRequ
 			return
 		}
 		state.RequestId = to.String(upgradeResp.ResponseContext.RequestId)
-
-		timeout, diag = state.Timeouts.Update(ctx, UpgradeDefaultTimeout)
-		if fwhelpers.CheckDiags(resp, diag) {
-			return
-		}
-		tflog.Info(ctx, fmt.Sprintf("Cluster upgrading. Timeout is set at %s.", timeout.String()))
 	}
+	state.Timeouts = plan.Timeouts
 
 	data, err := r.read(ctx, state, timeout)
 	if err != nil {

--- a/internal/services/oks/resource_oks_project.go
+++ b/internal/services/oks/resource_oks_project.go
@@ -16,11 +16,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/outscale/osc-sdk-go/v3/pkg/oks"
+	"github.com/outscale/osc-sdk-go/v3/pkg/options"
 	"github.com/outscale/terraform-provider-outscale/internal/client"
 	"github.com/outscale/terraform-provider-outscale/internal/framework/fwhelpers"
+	"github.com/outscale/terraform-provider-outscale/internal/framework/fwhelpers/from"
 	"github.com/outscale/terraform-provider-outscale/internal/framework/fwhelpers/to"
+	"github.com/outscale/terraform-provider-outscale/internal/framework/stateconf"
 	"github.com/outscale/terraform-provider-outscale/internal/framework/validators/validatorstring"
 )
 
@@ -165,6 +167,11 @@ func (r *oksProjectResource) Create(ctx context.Context, req resource.CreateRequ
 		return
 	}
 
+	timeout, diags := data.Timeouts.Create(ctx, CreateDefaultTimeout)
+	if fwhelpers.CheckDiags(resp, diags) {
+		return
+	}
+
 	input := oks.ProjectInput{
 		Cidr:   data.Cidr.ValueString(),
 		Name:   data.Name.ValueString(),
@@ -189,7 +196,7 @@ func (r *oksProjectResource) Create(ctx context.Context, req resource.CreateRequ
 	}
 	input.Tags = &tags
 
-	createResp, err := r.Client.CreateProject(ctx, input)
+	createResp, err := r.Client.CreateProject(ctx, input, options.WithRetryTimeout(timeout))
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Create Resource Project",
@@ -200,12 +207,7 @@ func (r *oksProjectResource) Create(ctx context.Context, req resource.CreateRequ
 	data.RequestId = to.String(createResp.ResponseContext.RequestId)
 	data.Id = to.String(createResp.Project.Id)
 
-	to, diags := data.Timeouts.Create(ctx, CreateDefaultTimeout)
-	if fwhelpers.CheckDiags(resp, diags) {
-		return
-	}
-
-	data, err = r.setOKSProjectState(ctx, data, to)
+	data, err = r.read(ctx, data, timeout)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to set Project state",
@@ -213,6 +215,7 @@ func (r *oksProjectResource) Create(ctx context.Context, req resource.CreateRequ
 		)
 		return
 	}
+
 	diags = resp.State.Set(ctx, &data)
 	resp.Diagnostics.Append(diags...)
 }
@@ -229,7 +232,7 @@ func (r *oksProjectResource) Read(ctx context.Context, req resource.ReadRequest,
 	if fwhelpers.CheckDiags(resp, diags) {
 		return
 	}
-	data, err := r.setOKSProjectState(ctx, data, to)
+	data, err := r.read(ctx, data, to)
 	if err != nil {
 		if oks.IsNotFound(err) {
 			resp.State.RemoveResource(ctx)
@@ -253,6 +256,11 @@ func (r *oksProjectResource) Update(ctx context.Context, req resource.UpdateRequ
 	diags := req.Plan.Get(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
 	diags = req.State.Get(ctx, &state)
+	if fwhelpers.CheckDiags(resp, diags) {
+		return
+	}
+
+	timeout, diags := plan.Timeouts.Update(ctx, UpdateDefaultTimeout)
 	if fwhelpers.CheckDiags(resp, diags) {
 		return
 	}
@@ -284,17 +292,19 @@ func (r *oksProjectResource) Update(ctx context.Context, req resource.UpdateRequ
 		update.Tags = &tags
 	}
 
-	updateResp, err := r.Client.UpdateProject(ctx, state.Id.ValueString(), update)
-	if err != nil {
-		return
-	}
-	state.RequestId = to.String(updateResp.ResponseContext.RequestId)
+	if update != (oks.ProjectUpdate{}) {
+		updateResp, err := r.Client.UpdateProject(ctx, state.Id.ValueString(), update, options.WithRetryTimeout(timeout))
+		if err != nil {
+			return
+		}
 
-	to, diags := state.Timeouts.Update(ctx, UpdateDefaultTimeout)
-	if fwhelpers.CheckDiags(resp, diags) {
-		return
+		state.RequestId = to.String(updateResp.ResponseContext.RequestId)
 	}
-	data, err := r.setOKSProjectState(ctx, state, to)
+
+	state.Timeouts = plan.Timeouts
+	state.Quirks = plan.Quirks
+
+	data, err := r.read(ctx, state, timeout)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to set Project state",
@@ -302,6 +312,7 @@ func (r *oksProjectResource) Update(ctx context.Context, req resource.UpdateRequ
 		)
 		return
 	}
+
 	diags = resp.State.Set(ctx, &data)
 	resp.Diagnostics.Append(diags...)
 }
@@ -313,7 +324,13 @@ func (r *oksProjectResource) Delete(ctx context.Context, req resource.DeleteRequ
 	if fwhelpers.CheckDiags(resp, diags) {
 		return
 	}
-	_, err := r.Client.DeleteProject(ctx, data.Id.ValueString())
+
+	timeout, diags := data.Timeouts.Delete(ctx, DeleteDefaultTimeout)
+	if fwhelpers.CheckDiags(resp, diags) {
+		return
+	}
+
+	_, err := r.Client.DeleteProject(ctx, data.Id.ValueString(), options.WithRetryTimeout(timeout))
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Delete Resource Project",
@@ -322,11 +339,7 @@ func (r *oksProjectResource) Delete(ctx context.Context, req resource.DeleteRequ
 		return
 	}
 
-	to, diags := data.Timeouts.Delete(ctx, DeleteDefaultTimeout)
-	if fwhelpers.CheckDiags(resp, diags) {
-		return
-	}
-	_, err = r.waitForProjectState(ctx, data.Id.ValueString(), []string{"deleting"}, []string{}, to)
+	_, err = r.waitForProjectState(ctx, data.Id.ValueString(), stateconf.States(oks.ProjectStatusDeleting), []oks.ProjectStatus{}, timeout)
 	if err != nil {
 		if !oks.IsNotFound(err) {
 			resp.Diagnostics.AddError("Unable to wait for Project complete deletion.", "Error: "+err.Error())
@@ -334,28 +347,29 @@ func (r *oksProjectResource) Delete(ctx context.Context, req resource.DeleteRequ
 	}
 }
 
-func (r *oksProjectResource) waitForProjectState(ctx context.Context, id string, pending []string, target []string, timeout time.Duration) (*oks.ProjectResponse, error) {
-	resp, err := fwhelpers.WaitForResource[oks.ProjectResponse](ctx, &retry.StateChangeConf{
+func (r *oksProjectResource) waitForProjectState(ctx context.Context, id string, pending []oks.ProjectStatus, target []oks.ProjectStatus, timeout time.Duration) (*oks.ProjectResponse, error) {
+	conf := stateconf.StateChangeConf[oks.ProjectStatus]{
 		Pending: pending,
 		Target:  target,
 		Timeout: timeout,
-		Refresh: func() (any, string, error) {
+		Refresh: func(ctx context.Context) (any, oks.ProjectStatus, error) {
 			resp, err := r.Client.GetProject(ctx, id)
 			if err != nil {
-				return resp, "", err
+				return nil, "", err
 			}
-			return resp, string(resp.Project.Status), nil
+			return resp, resp.Project.Status, nil
 		},
-	})
+	}
+	respAny, err := conf.WaitForStateContext(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	return resp, nil
+	return respAny.(*oks.ProjectResponse), nil
 }
 
-func (r *oksProjectResource) setOKSProjectState(ctx context.Context, data ProjectModel, timeout time.Duration) (ProjectModel, error) {
-	resp, err := r.waitForProjectState(ctx, data.Id.ValueString(), []string{"pending", "updating"}, []string{"ready", "deleting"}, timeout)
+func (r *oksProjectResource) read(ctx context.Context, data ProjectModel, timeout time.Duration) (ProjectModel, error) {
+	resp, err := r.waitForProjectState(ctx, data.Id.ValueString(), stateconf.States(oks.ProjectStatusPending, oks.ProjectStatusUpdating), stateconf.States(oks.ProjectStatusReady, oks.ProjectStatusDeleting), timeout)
 	if err != nil {
 		return data, err
 	}
@@ -374,7 +388,7 @@ func (r *oksProjectResource) setOKSProjectState(ctx context.Context, data Projec
 
 	tags, diags := flattenOKSTags(ctx, project.Tags)
 	if diags.HasError() {
-		return data, fmt.Errorf("%v", diags.Errors())
+		return data, from.Diag(diags)
 	}
 	data.Tags = tags
 


### PR DESCRIPTION
## Description

- After importing a resource, timeouts blocks declared in config would cause `inconsistent result` after apply. Some resources merges the api read return values to the state data, which does not contain the timeouts block value. In this situation we have to propagate the plan timeouts block before merging.

Fixes: #748

## Type of Change

Please check the relevant option(s):

- [X] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [X] Manual testing
- [ ] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [X] I have followed the [Contributing Guidelines](CONTRIBUTING.md)
* [X] I have added tests or explained why they are not needed
* [X] I have updated relevant documentation (README, examples, etc.)
* [X] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [X] My commits include appropriate [Gitmoji](https://gitmoji.dev/)
