### PR TITLE
🔒 ci: fix plumber lint

### DIFF
--- a/.github/workflows/all_acceptance.yml
+++ b/.github/workflows/all_acceptance.yml
@@ -6,6 +6,9 @@ on:
         - cron: "0 2 * * *"
     workflow_dispatch:
 
+permissions:
+    contents: read
+
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: true

--- a/.github/workflows/all_integration.yml
+++ b/.github/workflows/all_integration.yml
@@ -6,6 +6,9 @@ on:
         - cron: "0 2 * * *"
     workflow_dispatch:
 
+permissions:
+    contents: read
+
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: true

--- a/.github/workflows/generate_binaries_on_pr.yml
+++ b/.github/workflows/generate_binaries_on_pr.yml
@@ -12,6 +12,9 @@ on:
             - "GNUmakefile"
     workflow_dispatch:
 
+permissions:
+    contents: read
+
 jobs:
     goreleaser:
         runs-on: ubuntu-latest

--- a/.github/workflows/generate_doc.yml
+++ b/.github/workflows/generate_doc.yml
@@ -6,6 +6,9 @@ on:
                 description: "doc template tag repository"
                 required: true
 
+permissions:
+    contents: read
+
 jobs:
     doc-release:
         environment: auto-build

--- a/.github/workflows/oapi_integration.yml
+++ b/.github/workflows/oapi_integration.yml
@@ -26,6 +26,9 @@ on:
             - "GNUmakefile"
     workflow_dispatch:
 
+permissions:
+    contents: read
+
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: true

--- a/.github/workflows/oapi_nets_integration.yml
+++ b/.github/workflows/oapi_nets_integration.yml
@@ -26,6 +26,9 @@ on:
             - "GNUmakefile"
     workflow_dispatch:
 
+permissions:
+    contents: read
+
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: true

--- a/.github/workflows/oapi_nets_testacc.yml
+++ b/.github/workflows/oapi_nets_testacc.yml
@@ -20,6 +20,9 @@ on:
             - "GNUmakefile"
     workflow_dispatch:
 
+permissions:
+    contents: read
+
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: true

--- a/.github/workflows/oapi_others_testacc.yml
+++ b/.github/workflows/oapi_others_testacc.yml
@@ -20,6 +20,9 @@ on:
             - "GNUmakefile"
     workflow_dispatch:
 
+permissions:
+    contents: read
+
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: true

--- a/.github/workflows/oapi_vms_testacc.yml
+++ b/.github/workflows/oapi_vms_testacc.yml
@@ -20,6 +20,9 @@ on:
             - "GNUmakefile"
     workflow_dispatch:
 
+permissions:
+    contents: read
+
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: true

--- a/.github/workflows/oks_integration.yml
+++ b/.github/workflows/oks_integration.yml
@@ -26,6 +26,9 @@ on:
             - "GNUmakefile"
     workflow_dispatch:
 
+permissions:
+    contents: read
+
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: true

--- a/.github/workflows/oks_testacc.yml
+++ b/.github/workflows/oks_testacc.yml
@@ -20,6 +20,9 @@ on:
             - "GNUmakefile"
     workflow_dispatch:
 
+permissions:
+    contents: read
+
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,10 @@ on:
     push:
         tags:
             - "v*"
+
+permissions:
+    contents: write
+
 jobs:
     goreleaser:
         environment: release

--- a/.github/workflows/reusable_acceptance_test.yml
+++ b/.github/workflows/reusable_acceptance_test.yml
@@ -16,6 +16,9 @@ on:
                 required: true
                 type: string
 
+permissions:
+    contents: read
+
 jobs:
     acceptance-test:
         environment: test-${{ inputs.region }}

--- a/.github/workflows/reusable_integration_test.yml
+++ b/.github/workflows/reusable_integration_test.yml
@@ -16,6 +16,9 @@ on:
                 required: true
                 type: string
 
+permissions:
+    contents: read
+
 jobs:
     integration-test:
         environment: test-${{ inputs.region }}

--- a/.github/workflows/terraform_examples.yml
+++ b/.github/workflows/terraform_examples.yml
@@ -13,12 +13,15 @@ on:
         - cron: "30 22 * * *"
     workflow_dispatch:
 
+permissions:
+    contents: read
+
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: true
 
 jobs:
-    Examples_terraform_tests:
+    example-terraform-tests:
         environment: test-eu-west-2
         runs-on: [self-hosted, linux, eu-west-2, oapi]
         steps:

--- a/.github/workflows/tofu_examples.yml
+++ b/.github/workflows/tofu_examples.yml
@@ -13,12 +13,15 @@ on:
         - cron: "30 22 * * *"
     workflow_dispatch:
 
+permissions:
+    contents: read
+
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: true
 
 jobs:
-    Examples_tofu_tests:
+    examples-tofu-tests:
         environment: test-eu-west-2
         runs-on: [self-hosted, linux, eu-west-2, oapi]
         steps:


### PR DESCRIPTION
## Description

- This PR fixes most of Plumber lint errors. Using `secrets: inherit` on non-external reusable workflows still causes issues, removing it has a weird behavior (ref: https://github.com/actions/runner/issues/4453), so we're keeping it for now.

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [X] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [ ] Manual testing
- [ ] Unit tests
- [ ] Integration tests
- [X] Not tested yet

## Checklist

* [X] I have followed the [Contributing Guidelines](CONTRIBUTING.md)
* [X] I have added tests or explained why they are not needed
* [X] I have updated relevant documentation (README, examples, etc.)
* [X] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)
