### PR TITLE
:bug: endpoint in example raises a 404 error

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ provider "outscale" {
   access_key_id = var.access_key_id
   secret_key_id = var.secret_key_id
   api {
-    endpoint       = "https://api.eu-west-2.outscale.com"
+    endpoint       = "https://api.eu-west-2.outscale.com/api/v1"
     region         = "eu-west-2"
     x509_cert_path = "/path/to/cert.pem"
     x509_key_path  = "/path/to/key.pem"


### PR DESCRIPTION
# 📦 Pull Request Template

## Description

Just a quick fix to the documentation.  
Formerly, endpoint might have been `api.${myregion}.outscale.com`.  
Now (tested in `v1.6.0`), it has to be explicitly `https://api.${myregion}.outscale.com/api/v1`

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [x] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [ ] Manual testing
- [x] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

Commands used (if applicable):

A terraform plan using a simple `data outscale_images` is now OK.  
Using the former configuration for the provider endpoint was KO with a 404 error.


## Checklist

* [ ] I have followed the [Contributing Guidelines](CONTRIBUTING.md)
* [ ] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [ ] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)
