### PR TITLE
🐛 fix: delete resources on create failure

### DIFF
--- a/internal/services/oapi/ephemeral_keypair.go
+++ b/internal/services/oapi/ephemeral_keypair.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
 	"github.com/hashicorp/terraform-plugin-framework/ephemeral/schema"
 	"github.com/hashicorp/terraform-plugin-framework/path"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/outscale/goutils/sdk/ptr"
 	"github.com/outscale/osc-sdk-go/v3/pkg/options"
 	"github.com/outscale/osc-sdk-go/v3/pkg/osc"
@@ -20,21 +19,17 @@ import (
 
 var _ ephemeral.EphemeralResource = &resourceEphemeralKeypair{}
 
+const (
+	ephemeralKeypairErrCreate     = "Unable to create Ephemeral Keypair"
+	ephemeralKeypairErrExistCheck = "Unable to verify if the Keypair already exists"
+)
+
 type resourceEphemeralKeypair struct {
-	Client *osc.Client
+	keypairCommon
 }
 
 type EphemeralKeypairModel struct {
-	KeypairFingerprint types.String   `tfsdk:"keypair_fingerprint"`
-	PrivateKey         types.String   `tfsdk:"private_key"`
-	KeypairName        types.String   `tfsdk:"keypair_name"`
-	KeypairType        types.String   `tfsdk:"keypair_type"`
-	KeypairId          types.String   `tfsdk:"keypair_id"`
-	PublicKey          types.String   `tfsdk:"public_key"`
-	RequestId          types.String   `tfsdk:"request_id"`
-	Timeouts           timeouts.Value `tfsdk:"timeouts"`
-	Id                 types.String   `tfsdk:"id"`
-	TagsModel
+	KeypairModel
 }
 
 func NewKeypairEphemeralResource() ephemeral.EphemeralResource {
@@ -125,16 +120,17 @@ func (r *resourceEphemeralKeypair) Schema(ctx context.Context, _ ephemeral.Schem
 func (e *resourceEphemeralKeypair) Open(ctx context.Context, req ephemeral.OpenRequest, resp *ephemeral.OpenResponse) {
 	var data EphemeralKeypairModel
 
-	// Read Terraform config data into the model
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	createTimeout, diags := data.Timeouts.Create(ctx, CreateDefaultTimeout)
+
+	timeout, diags := data.Timeouts.Create(ctx, CreateDefaultTimeout)
 	if fwhelpers.CheckDiags(resp, diags) {
 		return
 	}
-	resp.RenewAt = time.Now().Add(createTimeout)
+
+	resp.RenewAt = time.Now().Add(timeout)
 
 	createReq := osc.CreateKeypairRequest{}
 	createReq.KeypairName = data.KeypairName.ValueString()
@@ -143,21 +139,15 @@ func (e *resourceEphemeralKeypair) Open(ctx context.Context, req ephemeral.OpenR
 		createReq.PublicKey = data.PublicKey.ValueStringPointer()
 	}
 
-	isExit, err := isResourceExist(ctx, &data, e)
+	isExit, err := e.isResourceExist(ctx, timeout, &data)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to check whether the keypair resource already exists",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(ephemeralKeypairErrExistCheck, err.Error())
 		return
 	}
 	if !isExit {
-		createResp, err := e.Client.CreateKeypair(ctx, createReq, options.WithRetryTimeout(createTimeout))
+		createResp, err := e.Client.CreateKeypair(ctx, createReq, options.WithRetryTimeout(timeout))
 		if err != nil {
-			resp.Diagnostics.AddError(
-				"Unable to create ephemeral keypair resource",
-				err.Error(),
-			)
+			resp.Diagnostics.AddError(ephemeralKeypairErrCreate, err.Error())
 			return
 		}
 
@@ -168,15 +158,20 @@ func (e *resourceEphemeralKeypair) Open(ctx context.Context, req ephemeral.OpenR
 		if createReq.PublicKey != nil {
 			data.PublicKey = to.String(createReq.PublicKey)
 		}
-		data.PrivateKey = to.String(keypair.PrivateKey)
 
-		diag := createOAPITagsFW(ctx, e.Client, createTimeout, data.Tags, *keypair.KeypairId)
+		stateData := e.flattenCreate(data.KeypairModel, keypair)
+		diag := resp.Result.Set(ctx, &stateData)
+		if fwhelpers.CheckDiags(resp, diag) {
+			return
+		}
+
+		diag = createOAPITagsFW(ctx, e.Client, timeout, data.Tags, *keypair.KeypairId)
 		if fwhelpers.CheckDiags(resp, diag) {
 			return
 		}
 	}
 
-	err = setEphKeypairState(ctx, e, &data)
+	stateData, err := e.read(ctx, timeout, data.KeypairModel)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to set ephemeral keypair state",
@@ -201,58 +196,18 @@ func (e *resourceEphemeralKeypair) Open(ctx context.Context, req ephemeral.OpenR
 	// if resp.Diagnostics.HasError() {
 	// 	return
 	// }
-	resp.Diagnostics.Append(resp.Result.Set(ctx, &data)...)
+	resp.Diagnostics.Append(resp.Result.Set(ctx, &stateData)...)
 }
 
-func setEphKeypairState(ctx context.Context, r *resourceEphemeralKeypair, data *EphemeralKeypairModel) error {
+func (r *resourceEphemeralKeypair) isResourceExist(ctx context.Context, timeout time.Duration, data *EphemeralKeypairModel) (bool, error) {
 	keypairFilters := osc.FiltersKeypair{
 		KeypairNames: &[]string{data.KeypairName.ValueString()},
-	}
-
-	readTimeout, diags := data.Timeouts.Read(ctx, ReadDefaultTimeout)
-	if diags.HasError() {
-		return fmt.Errorf("unable to parse 'keypair' read timeout value: %v", diags.Errors())
 	}
 
 	readReq := osc.ReadKeypairsRequest{
 		Filters: &keypairFilters,
 	}
-	readResp, err := r.Client.ReadKeypairs(ctx, readReq, options.WithRetryTimeout(readTimeout))
-	if err != nil {
-		return err
-	}
-	if readResp.Keypairs == nil || len(*readResp.Keypairs) == 0 {
-		return ErrResourceEmpty
-	}
-
-	keypair := (*readResp.Keypairs)[0]
-
-	tags, diag := flattenOAPITagsFW(ctx, ptr.From(keypair.Tags))
-	if diag.HasError() {
-		return fmt.Errorf("unable to flatten tags: %v", diags.Errors())
-	}
-	data.Tags = tags
-	data.KeypairFingerprint = to.String(ptr.From(keypair.KeypairFingerprint))
-	data.KeypairName = to.String(ptr.From(keypair.KeypairName))
-	data.KeypairType = to.String(ptr.From(keypair.KeypairType))
-	data.KeypairId = to.String(ptr.From(keypair.KeypairId))
-
-	return nil
-}
-
-func isResourceExist(ctx context.Context, data *EphemeralKeypairModel, e *resourceEphemeralKeypair) (bool, error) {
-	keypairFilters := osc.FiltersKeypair{
-		KeypairNames: &[]string{data.KeypairName.ValueString()},
-	}
-	readTimeout, diags := data.Timeouts.Read(ctx, ReadDefaultTimeout)
-	if diags.HasError() {
-		return false, fmt.Errorf("unable to parse 'ephemeral keypair' read timeout value: %v", diags.Errors())
-	}
-
-	readReq := osc.ReadKeypairsRequest{
-		Filters: &keypairFilters,
-	}
-	rp, err := e.Client.ReadKeypairs(ctx, readReq, options.WithRetryTimeout(readTimeout))
+	rp, err := r.Client.ReadKeypairs(ctx, readReq, options.WithRetryTimeout(timeout))
 	if err != nil {
 		return false, err
 	}

--- a/internal/services/oapi/errors.go
+++ b/internal/services/oapi/errors.go
@@ -21,3 +21,6 @@ var (
 
 	ErrFilterRequired = errors.New("filters must be assigned")
 )
+
+// Global errors
+const errSetTerraformState = "Unable to reconcile Terraform state from API response"

--- a/internal/services/oapi/resource_access_key.go
+++ b/internal/services/oapi/resource_access_key.go
@@ -179,7 +179,7 @@ func (r *resourceAccessKey) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 
-	createTimeout, diags := data.Timeouts.Create(ctx, CreateDefaultTimeout)
+	timeout, diags := data.Timeouts.Create(ctx, CreateDefaultTimeout)
 	if fwhelpers.CheckDiags(resp, diags) {
 		return
 	}
@@ -200,7 +200,7 @@ func (r *resourceAccessKey) Create(ctx context.Context, req resource.CreateReque
 		createReq.Tag = new(data.Tag.ValueString())
 	}
 
-	createResp, err := r.Client.CreateAccessKey(ctx, createReq, options.WithRetryTimeout(createTimeout))
+	createResp, err := r.Client.CreateAccessKey(ctx, createReq, options.WithRetryTimeout(timeout))
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to create access_key resource",
@@ -214,8 +214,14 @@ func (r *resourceAccessKey) Create(ctx context.Context, req resource.CreateReque
 	data.Id = to.String(ptr.From(accessKey.AccessKeyId))
 	data.SecretKey = to.String(ptr.From(accessKey.SecretKey))
 
+	stateData := r.flattenCreate(data, accessKey)
+	diag := resp.State.Set(ctx, &stateData)
+	if fwhelpers.CheckDiags(resp, diag) {
+		return
+	}
+
 	if data.State.ValueString() != "ACTIVE" {
-		if err := inactiveAccessKey(ctx, createTimeout, r, data); err != nil {
+		if err := inactiveAccessKey(ctx, timeout, r, data); err != nil {
 			resp.Diagnostics.AddError(
 				"Unable to update access_key state",
 				err.Error(),
@@ -224,16 +230,13 @@ func (r *resourceAccessKey) Create(ctx context.Context, req resource.CreateReque
 		}
 	}
 
-	err = setAccessKeyState(ctx, r, &data)
+	stateData, err = r.read(ctx, timeout, data)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to set access_key state",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateData)...)
 }
 
 func (r *resourceAccessKey) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -244,19 +247,22 @@ func (r *resourceAccessKey) Read(ctx context.Context, req resource.ReadRequest, 
 		return
 	}
 
-	err := setAccessKeyState(ctx, r, &data)
+	timeout, diags := data.Timeouts.Read(ctx, ReadDefaultTimeout)
+	if fwhelpers.CheckDiags(resp, diags) {
+		return
+	}
+
+	stateData, err := r.read(ctx, timeout, data)
 	if err != nil {
 		if errors.Is(err, ErrResourceEmpty) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(
-			"Unable to set access_key API response values.",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateData)...)
 }
 
 func (r *resourceAccessKey) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
@@ -271,7 +277,7 @@ func (r *resourceAccessKey) Update(ctx context.Context, req resource.UpdateReque
 		return
 	}
 
-	updateTimeout, diags := planData.Timeouts.Update(ctx, UpdateDefaultTimeout)
+	timeout, diags := planData.Timeouts.Update(ctx, UpdateDefaultTimeout)
 	if fwhelpers.CheckDiags(resp, diags) {
 		return
 	}
@@ -304,7 +310,7 @@ func (r *resourceAccessKey) Update(ctx context.Context, req resource.UpdateReque
 		stateData.Tag = planData.Tag
 	}
 
-	_, err := r.Client.UpdateAccessKey(ctx, updateReq, options.WithRetryTimeout(updateTimeout))
+	_, err := r.Client.UpdateAccessKey(ctx, updateReq, options.WithRetryTimeout(timeout))
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to update access_key resource",
@@ -314,16 +320,13 @@ func (r *resourceAccessKey) Update(ctx context.Context, req resource.UpdateReque
 	}
 
 	stateData.Timeouts = planData.Timeouts
-	err = setAccessKeyState(ctx, r, &stateData)
+	newData, err := r.read(ctx, timeout, stateData)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to update access_key API response values.",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &stateData)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &newData)...)
 }
 
 func (r *resourceAccessKey) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
@@ -365,13 +368,9 @@ func (r *resourceAccessKey) Delete(ctx context.Context, req resource.DeleteReque
 	}
 }
 
-func setAccessKeyState(ctx context.Context, r *resourceAccessKey, data *AccessKeyModel) error {
+func (r *resourceAccessKey) read(ctx context.Context, timeout time.Duration, data AccessKeyModel) (AccessKeyModel, error) {
 	accessKeyFilters := osc.FiltersAccessKeys{
 		AccessKeyIds: &[]string{data.Id.ValueString()},
-	}
-	readTimeout, diags := data.Timeouts.Read(ctx, ReadDefaultTimeout)
-	if diags.HasError() {
-		return fmt.Errorf("unable to parse 'access_key' read timeout value: %v", diags.Errors())
 	}
 
 	readReq := osc.ReadAccessKeysRequest{
@@ -381,12 +380,12 @@ func setAccessKeyState(ctx context.Context, r *resourceAccessKey, data *AccessKe
 		readReq.UserName = data.UserName.ValueStringPointer()
 	}
 
-	readResp, err := r.Client.ReadAccessKeys(ctx, readReq, options.WithRetryTimeout(readTimeout))
+	readResp, err := r.Client.ReadAccessKeys(ctx, readReq, options.WithRetryTimeout(timeout))
 	if err != nil {
-		return err
+		return data, err
 	}
 	if readResp.AccessKeys == nil || len(*readResp.AccessKeys) == 0 {
-		return ErrResourceEmpty
+		return data, ErrResourceEmpty
 	}
 
 	data.RequestId = to.String(readResp.ResponseContext.RequestId)
@@ -405,7 +404,23 @@ func setAccessKeyState(ctx context.Context, r *resourceAccessKey, data *AccessKe
 		data.ExpirationDate = apiExpiration
 	}
 
-	return nil
+	return data, nil
+}
+
+func (r *resourceAccessKey) flattenCreate(data AccessKeyModel, key osc.AccessKeySecretKey) AccessKeyModel {
+	data.Id = to.String(key.AccessKeyId)
+	data.SecretKey = to.String(key.SecretKey)
+	data.AccessKeyId = to.String(key.AccessKeyId)
+	data.State = to.String(ptr.From(key.State))
+	data.CreationDate = to.String(from.ISO8601(key.CreationDate))
+	data.LastModificationDate = to.String(from.ISO8601(key.LastModificationDate))
+
+	apiExpiration := to.ISO8601Value(key.ExpirationDate)
+	if !apiExpiration.IsNull() || data.ExpirationDate.IsUnknown() || data.ExpirationDate.ValueString() != "" {
+		data.ExpirationDate = apiExpiration
+	}
+
+	return data
 }
 
 func inactiveAccessKey(ctx context.Context, timeout time.Duration, r *resourceAccessKey, data AccessKeyModel) error {

--- a/internal/services/oapi/resource_api_access_policy.go
+++ b/internal/services/oapi/resource_api_access_policy.go
@@ -27,6 +27,11 @@ var (
 	_ resource.ResourceWithValidateConfig = &resourceApiAccessPolicy{}
 )
 
+const (
+	apiAccessPolicyErrCreate = "Unable to create Api Access Policy"
+	apiAccessPolicyErrUpdate = "Unable to update Api Access Policy"
+)
+
 type apiAccessPolicyModel struct {
 	MaxAccessKeyExpirationSeconds types.Int64    `tfsdk:"max_access_key_expiration_seconds"`
 	RequireTrustedEnv             types.Bool     `tfsdk:"require_trusted_env"`
@@ -113,7 +118,7 @@ func (r *resourceApiAccessPolicy) Create(ctx context.Context, req resource.Creat
 	var data apiAccessPolicyModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
 
-	createTimeout, diag := data.Timeouts.Create(ctx, CreateDefaultTimeout)
+	timeout, diag := data.Timeouts.Create(ctx, CreateDefaultTimeout)
 	if fwhelpers.CheckDiags(resp, diag) {
 		return
 	}
@@ -123,24 +128,15 @@ func (r *resourceApiAccessPolicy) Create(ctx context.Context, req resource.Creat
 		RequireTrustedEnv:             data.RequireTrustedEnv.ValueBool(),
 	}
 
-	_, err := r.Client.UpdateApiAccessPolicy(ctx, createReq, options.WithRetryTimeout(createTimeout))
+	createResp, err := r.Client.UpdateApiAccessPolicy(ctx, createReq, options.WithRetryTimeout(timeout))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to modify Api Access Policy",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(apiAccessPolicyErrCreate, err.Error())
 		return
 	}
 	data.Id = to.String(id.UniqueId())
+	data.RequestId = to.String(createResp.ResponseContext.RequestId)
 
-	stateData, err := r.read(ctx, createTimeout, data)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to get Api Access Policy response values",
-			err.Error(),
-		)
-		return
-	}
+	stateData := r.flatten(data, *createResp.ApiAccessPolicy)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &stateData)...)
 }
@@ -160,10 +156,7 @@ func (r *resourceApiAccessPolicy) Read(ctx context.Context, req resource.ReadReq
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(
-			"Unable to get Api Access Policy response values",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
@@ -194,10 +187,8 @@ func (r *resourceApiAccessPolicy) Update(ctx context.Context, req resource.Updat
 
 	_, err := r.Client.UpdateApiAccessPolicy(ctx, updateReq, options.WithRetryTimeout(timeout))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to update Api Access Policy",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(apiAccessPolicyErrUpdate, err.Error())
+		return
 	}
 
 	stateData.Timeouts = planData.Timeouts
@@ -207,10 +198,7 @@ func (r *resourceApiAccessPolicy) Update(ctx context.Context, req resource.Updat
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(
-			"Unable to get Api Access Policy response values",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
@@ -231,8 +219,12 @@ func (r *resourceApiAccessPolicy) read(ctx context.Context, timeout time.Duratio
 	data.RequestId = to.String(resp.ResponseContext.RequestId)
 	policy := ptr.From(resp.ApiAccessPolicy)
 
+	return r.flatten(data, policy), nil
+}
+
+func (r *resourceApiAccessPolicy) flatten(data apiAccessPolicyModel, policy osc.ApiAccessPolicy) apiAccessPolicyModel {
 	data.MaxAccessKeyExpirationSeconds = to.Int64(ptr.From(policy.MaxAccessKeyExpirationSeconds))
 	data.RequireTrustedEnv = to.Bool(ptr.From(policy.RequireTrustedEnv))
 
-	return data, nil
+	return data
 }

--- a/internal/services/oapi/resource_api_access_rule.go
+++ b/internal/services/oapi/resource_api_access_rule.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/outscale/terraform-provider-outscale/internal/client"
 	"github.com/outscale/terraform-provider-outscale/internal/framework/fwhelpers"
+	"github.com/outscale/terraform-provider-outscale/internal/framework/fwhelpers/from"
 	"github.com/outscale/terraform-provider-outscale/internal/framework/fwhelpers/to"
 	"github.com/outscale/terraform-provider-outscale/internal/framework/validators/validatorstring"
 )
@@ -30,6 +31,12 @@ var (
 	_ resource.Resource                = &resourceApiAccessRule{}
 	_ resource.ResourceWithConfigure   = &resourceApiAccessRule{}
 	_ resource.ResourceWithImportState = &resourceApiAccessRule{}
+)
+
+const (
+	apiAccessRuleErrCreate = "Unable to create Api Access Rule"
+	apiAccessRuleErrUpdate = "Unable to update Api Access Rule"
+	apiAccessRuleErrDelete = "Unable to delete Api Access Rule"
 )
 
 type apiAccessRuleModel struct {
@@ -136,7 +143,7 @@ func (r *resourceApiAccessRule) Create(ctx context.Context, req resource.CreateR
 	var data apiAccessRuleModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
 
-	createTimeout, diag := data.Timeouts.Create(ctx, CreateDefaultTimeout)
+	timeout, diag := data.Timeouts.Create(ctx, CreateDefaultTimeout)
 	if fwhelpers.CheckDiags(resp, diag) {
 		return
 	}
@@ -168,22 +175,17 @@ func (r *resourceApiAccessRule) Create(ctx context.Context, req resource.CreateR
 		createReq.Description = data.Description.ValueStringPointer()
 	}
 
-	createResp, err := r.Client.CreateApiAccessRule(ctx, createReq, options.WithRetryTimeout(createTimeout))
+	createResp, err := r.Client.CreateApiAccessRule(ctx, createReq, options.WithRetryTimeout(timeout))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to create Api Access Rule",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(apiAccessRuleErrCreate, err.Error())
 		return
 	}
+	data.RequestId = to.String(createResp.ResponseContext.RequestId)
 	data.Id = to.String(createResp.ApiAccessRule.ApiAccessRuleId)
 
-	stateData, err := r.read(ctx, createTimeout, data)
+	stateData, err := r.flatten(ctx, data, *createResp.ApiAccessRule)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to set Api Access Rule state",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
@@ -205,10 +207,7 @@ func (r *resourceApiAccessRule) Read(ctx context.Context, req resource.ReadReque
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(
-			"Unable to get Api Access Rule response values",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
@@ -259,10 +258,8 @@ func (r *resourceApiAccessRule) Update(ctx context.Context, req resource.UpdateR
 
 	_, err := r.Client.UpdateApiAccessRule(ctx, updateReq, options.WithRetryTimeout(timeout))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to update Api Access Rule",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(apiAccessRuleErrUpdate, err.Error())
+		return
 	}
 
 	stateData.Timeouts = planData.Timeouts
@@ -272,10 +269,7 @@ func (r *resourceApiAccessRule) Update(ctx context.Context, req resource.UpdateR
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(
-			"Unable to read Api Access Rule response values",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
@@ -297,10 +291,7 @@ func (r *resourceApiAccessRule) Delete(ctx context.Context, req resource.DeleteR
 
 	_, err := r.Client.DeleteApiAccessRule(ctx, deleteReq, options.WithRetryTimeout(timeout))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to delete Api Access Rule",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(apiAccessRuleErrDelete, err.Error())
 	}
 }
 
@@ -322,17 +313,21 @@ func (r *resourceApiAccessRule) read(ctx context.Context, timeout time.Duration,
 	data.RequestId = to.String(resp.ResponseContext.RequestId)
 	rule := (*resp.ApiAccessRules)[0]
 
+	return r.flatten(ctx, data, rule)
+}
+
+func (r *resourceApiAccessRule) flatten(ctx context.Context, data apiAccessRuleModel, rule osc.ApiAccessRule) (apiAccessRuleModel, error) {
 	caIds, diag := to.Set(ctx, ptr.From(rule.CaIds))
 	if diag.HasError() {
-		return data, fmt.Errorf("unable to convert ca_ids into a set: %v", diag.Errors())
+		return data, from.Diag(diag)
 	}
 	cns, diag := to.Set(ctx, ptr.From(rule.Cns))
 	if diag.HasError() {
-		return data, fmt.Errorf("unable to convert cns into a set: %v", diag.Errors())
+		return data, from.Diag(diag)
 	}
 	ipRanges, diag := to.Set(ctx, ptr.From(rule.IpRanges))
 	if diag.HasError() {
-		return data, fmt.Errorf("unable to convert ip_ranges into a set: %v", diag.Errors())
+		return data, from.Diag(diag)
 	}
 
 	data.CaIds = caIds

--- a/internal/services/oapi/resource_ca.go
+++ b/internal/services/oapi/resource_ca.go
@@ -27,6 +27,12 @@ var (
 	_ resource.ResourceWithImportState = &resoureCa{}
 )
 
+const (
+	caErrCreate = "Unable to create CA"
+	caErrUpdate = "Unable to update CA"
+	caErrDelete = "Unable to delete CA"
+)
+
 type caModel struct {
 	CaPem         types.String   `tfsdk:"ca_pem"`
 	CaFingerprint types.String   `tfsdk:"ca_fingerprint"`
@@ -116,7 +122,7 @@ func (r *resoureCa) Create(ctx context.Context, req resource.CreateRequest, resp
 	var data caModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
 
-	createTimeout, diag := data.Timeouts.Create(ctx, CreateDefaultTimeout)
+	timeout, diag := data.Timeouts.Create(ctx, CreateDefaultTimeout)
 	if fwhelpers.CheckDiags(resp, diag) {
 		return
 	}
@@ -129,24 +135,15 @@ func (r *resoureCa) Create(ctx context.Context, req resource.CreateRequest, resp
 		createReq.Description = data.Description.ValueStringPointer()
 	}
 
-	createResp, err := r.Client.CreateCa(ctx, createReq, options.WithRetryTimeout(createTimeout))
+	createResp, err := r.Client.CreateCa(ctx, createReq, options.WithRetryTimeout(timeout))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to create Ca",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(caErrCreate, err.Error())
 		return
 	}
+	data.RequestId = to.String(createResp.ResponseContext.RequestId)
 	data.Id = to.String(createResp.Ca.CaId)
 
-	stateData, err := r.read(ctx, createTimeout, data)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to set Ca state",
-			err.Error(),
-		)
-		return
-	}
+	stateData := r.flatten(data, *createResp.Ca)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &stateData)...)
 }
@@ -166,10 +163,7 @@ func (r *resoureCa) Read(ctx context.Context, req resource.ReadRequest, resp *re
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(
-			"Unable to set Ca API response values",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
@@ -198,10 +192,8 @@ func (r *resoureCa) Update(ctx context.Context, req resource.UpdateRequest, resp
 
 	_, err := r.Client.UpdateCa(ctx, updateReq, options.WithRetryTimeout(timeout))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to update Ca",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(caErrUpdate, err.Error())
+		return
 	}
 
 	stateData.Timeouts = planData.Timeouts
@@ -211,10 +203,7 @@ func (r *resoureCa) Update(ctx context.Context, req resource.UpdateRequest, resp
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(
-			"Unable to set Ca API response values",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
@@ -236,10 +225,7 @@ func (r *resoureCa) Delete(ctx context.Context, req resource.DeleteRequest, resp
 
 	_, err := r.Client.DeleteCa(ctx, deleteReq, options.WithRetryTimeout(timeout))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to delete Ca",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(caErrDelete, err.Error())
 	}
 }
 
@@ -261,10 +247,14 @@ func (r *resoureCa) read(ctx context.Context, timeout time.Duration, data caMode
 	data.RequestId = to.String(resp.ResponseContext.RequestId)
 	ca := (*resp.Cas)[0]
 
+	return r.flatten(data, ca), nil
+}
+
+func (r *resoureCa) flatten(data caModel, ca osc.Ca) caModel {
 	data.Id = to.String(ca.CaId)
 	data.CaFingerprint = to.String(ca.CaFingerprint)
 	data.CaId = to.String(ca.CaId)
 	data.Description = to.String(ca.Description)
 
-	return data, nil
+	return data
 }

--- a/internal/services/oapi/resource_client_gateway.go
+++ b/internal/services/oapi/resource_client_gateway.go
@@ -19,6 +19,7 @@ import (
 	"github.com/outscale/osc-sdk-go/v3/pkg/osc"
 	"github.com/outscale/terraform-provider-outscale/internal/client"
 	"github.com/outscale/terraform-provider-outscale/internal/framework/fwhelpers"
+	"github.com/outscale/terraform-provider-outscale/internal/framework/fwhelpers/from"
 	"github.com/outscale/terraform-provider-outscale/internal/framework/fwhelpers/to"
 	"github.com/outscale/terraform-provider-outscale/internal/framework/stateconf"
 )
@@ -31,9 +32,7 @@ var (
 
 const (
 	clientGwErrCreate = "Unable to create Client Gateway"
-	clientGwErrRead   = "Unable to read Client Gateway"
 	clientGwErrDelete = "Unable to delete Client Gateway"
-	clientGwErrState  = "Unable to set Client Gateway state"
 )
 
 type clientGatewayModel struct {
@@ -178,8 +177,19 @@ func (r *clientGatewayResource) Create(ctx context.Context, req resource.CreateR
 		return
 	}
 
+	data.RequestId = to.String(createResp.ResponseContext.RequestId)
 	data.Id = to.String(createResp.ClientGateway.ClientGatewayId)
 	data.ClientGatewayId = to.String(createResp.ClientGateway.ClientGatewayId)
+
+	stateData, err := r.flatten(ctx, data, *createResp.ClientGateway)
+	if err != nil {
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
+		return
+	}
+	diags = resp.State.Set(ctx, &stateData)
+	if fwhelpers.CheckDiags(resp, diags) {
+		return
+	}
 
 	diag := createOAPITagsFW(ctx, r.Client, timeout, data.Tags, createResp.ClientGateway.ClientGatewayId)
 	if fwhelpers.CheckDiags(resp, diag) {
@@ -190,17 +200,17 @@ func (r *clientGatewayResource) Create(ctx context.Context, req resource.CreateR
 		Pending: stateconf.States(osc.ClientGatewayStatePending),
 		Target:  stateconf.States(osc.ClientGatewayStateAvailable),
 		Timeout: timeout,
-		Refresh: r.stateRefreshFunc(createResp.ClientGateway.ClientGatewayId),
+		Refresh: r.refreshFunc(createResp.ClientGateway.ClientGatewayId),
 	}
-	_, err = stateConf.WaitForStateContext(ctx)
+	gatewayAny, err := stateConf.WaitForStateContext(ctx)
 	if err != nil {
-		resp.Diagnostics.AddError(clientGwErrState, err.Error())
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
-	stateData, err := r.read(ctx, timeout, data)
+	stateData, err = r.flatten(ctx, data, gatewayAny.(osc.ClientGateway))
 	if err != nil {
-		resp.Diagnostics.AddError(clientGwErrState, err.Error())
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
@@ -222,7 +232,7 @@ func (r *clientGatewayResource) Read(ctx context.Context, req resource.ReadReque
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(clientGwErrRead, err.Error())
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
@@ -253,7 +263,7 @@ func (r *clientGatewayResource) Update(ctx context.Context, req resource.UpdateR
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(clientGwErrState, err.Error())
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
@@ -286,7 +296,7 @@ func (r *clientGatewayResource) Delete(ctx context.Context, req resource.DeleteR
 		Pending: stateconf.States(osc.ClientGatewayStateDeleting),
 		Target:  stateconf.States(osc.ClientGatewayStateDeleted),
 		Timeout: timeout,
-		Refresh: r.stateRefreshFunc(data.Id.ValueString()),
+		Refresh: r.refreshFunc(data.Id.ValueString()),
 	}
 	_, err = stateConf.WaitForStateContext(ctx)
 	switch {
@@ -313,14 +323,18 @@ func (r *clientGatewayResource) read(ctx context.Context, timeout time.Duration,
 	}
 
 	gw := (*resp.ClientGateways)[0]
+	data.RequestId = to.String(resp.ResponseContext.RequestId)
 
+	return r.flatten(ctx, data, gw)
+}
+
+func (r *clientGatewayResource) flatten(ctx context.Context, data clientGatewayModel, gw osc.ClientGateway) (clientGatewayModel, error) {
 	tags, diag := flattenOAPITagsFW(ctx, gw.Tags)
 	if diag.HasError() {
-		return data, fmt.Errorf("%v", diag.Errors())
+		return data, from.Diag(diag)
 	}
 
 	data.Tags = tags
-	data.RequestId = to.String(resp.ResponseContext.RequestId)
 	data.Id = to.String(gw.ClientGatewayId)
 	data.ClientGatewayId = to.String(gw.ClientGatewayId)
 	data.BgpAsn = to.Int64(gw.BgpAsn)
@@ -331,7 +345,7 @@ func (r *clientGatewayResource) read(ctx context.Context, timeout time.Duration,
 	return data, nil
 }
 
-func (r *clientGatewayResource) stateRefreshFunc(id string) stateconf.StateRefreshFunc[osc.ClientGatewayState] {
+func (r *clientGatewayResource) refreshFunc(id string) stateconf.StateRefreshFunc[osc.ClientGatewayState] {
 	return func(ctx context.Context) (any, osc.ClientGatewayState, error) {
 		req := osc.ReadClientGatewaysRequest{
 			Filters: &osc.FiltersClientGateway{
@@ -349,6 +363,6 @@ func (r *clientGatewayResource) stateRefreshFunc(id string) stateconf.StateRefre
 
 		gw := (*resp.ClientGateways)[0]
 
-		return resp, gw.State, nil
+		return gw, gw.State, nil
 	}
 }

--- a/internal/services/oapi/resource_client_gateway_test.go
+++ b/internal/services/oapi/resource_client_gateway_test.go
@@ -3,6 +3,7 @@ package oapi_test
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -41,7 +42,31 @@ func TestAccOthers_ClientGateway_Migration(t *testing.T) {
 	})
 }
 
+func TestAccOthers_ClientGateway_CreateFailureKeepsState(t *testing.T) {
+	resourceName := "outscale_client_gateway.foo"
+	rBgpAsn := oapihelpers.RandBgpAsn()
+	invalidTagKey := strings.Repeat("a", 256)
+	tagValue := "testacc-client-gateway"
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testacc.ProtoV6ProviderFactories(),
+		Steps: testacc.CreateFailureReplacementSteps(
+			resourceName,
+			testAccClientGatewayConfigWithTag(rBgpAsn, invalidTagKey, tagValue),
+			testAccClientGatewayConfigWithTag(rBgpAsn, "Name", tagValue),
+			resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttrSet(resourceName, "client_gateway_id"),
+				resource.TestCheckResourceAttr(resourceName, "tags.0.value", tagValue),
+			),
+		),
+	})
+}
+
 func testAccClientGatewayConfig(rBgpAsn int) string {
+	return testAccClientGatewayConfigWithTag(rBgpAsn, "Name", "testacc-client-gateway")
+}
+
+func testAccClientGatewayConfigWithTag(rBgpAsn int, tagKey, tagValue string) string {
 	return fmt.Sprintf(`
 		resource "outscale_client_gateway" "foo" {
 			bgp_asn         = %d
@@ -49,9 +74,9 @@ func testAccClientGatewayConfig(rBgpAsn int) string {
 			connection_type = "ipsec.1"
 
 			tags {
-				key = "Name"
-				value = "testacc-client-gateway"
+				key = %q
+				value = %q
 			}
 		}
-	`, rBgpAsn)
+	`, rBgpAsn, tagKey, tagValue)
 }

--- a/internal/services/oapi/resource_dhcp_option.go
+++ b/internal/services/oapi/resource_dhcp_option.go
@@ -33,9 +33,7 @@ var (
 
 const (
 	dhcpErrCreate  = "Unable to create DHCP Option"
-	dhcpErrRead    = "Unable to read DHCP Option"
 	dhcpErrDelete  = "Unable to delete DHCP Option"
-	dhcpErrState   = "Unable to set DHCP Option state"
 	dhcpErrDetach  = "Unable to detach DHCP Option from Nets"
 	dhcpErrGetNets = "Unable to get attached Nets of DHCP Option"
 )
@@ -236,17 +234,28 @@ func (r *dhcpOptionResource) Create(ctx context.Context, req resource.CreateRequ
 	}
 
 	dhcpId := ptr.From(createResp.DhcpOptionsSet.DhcpOptionsSetId)
+	data.RequestId = to.String(createResp.ResponseContext.RequestId)
 	data.Id = to.String(dhcpId)
 	data.DhcpOptionsSetId = to.String(dhcpId)
+
+	stateData, err := r.flatten(ctx, data, *createResp.DhcpOptionsSet)
+	if err != nil {
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
+		return
+	}
+	diags = resp.State.Set(ctx, &stateData)
+	if fwhelpers.CheckDiags(resp, diags) {
+		return
+	}
 
 	diag := createOAPITagsFW(ctx, r.Client, timeout, data.Tags, dhcpId)
 	if fwhelpers.CheckDiags(resp, diag) {
 		return
 	}
 
-	stateData, err := r.read(ctx, timeout, data)
+	stateData, err = r.read(ctx, timeout, data)
 	if err != nil {
-		resp.Diagnostics.AddError(dhcpErrState, err.Error())
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
@@ -268,7 +277,7 @@ func (r *dhcpOptionResource) Read(ctx context.Context, req resource.ReadRequest,
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(dhcpErrRead, err.Error())
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
@@ -299,7 +308,7 @@ func (r *dhcpOptionResource) Update(ctx context.Context, req resource.UpdateRequ
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(dhcpErrState, err.Error())
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
@@ -366,7 +375,12 @@ func (r *dhcpOptionResource) read(ctx context.Context, timeout time.Duration, da
 	}
 
 	dhcp := (*resp.DhcpOptionsSets)[0]
+	data.RequestId = to.String(resp.ResponseContext.RequestId)
 
+	return r.flatten(ctx, data, dhcp)
+}
+
+func (r *dhcpOptionResource) flatten(ctx context.Context, data dhcpOptionModel, dhcp osc.DhcpOptionsSet) (dhcpOptionModel, error) {
 	tags, diag := flattenOAPITagsFW(ctx, ptr.From(dhcp.Tags))
 	if diag.HasError() {
 		return data, from.Diag(diag)
@@ -386,7 +400,6 @@ func (r *dhcpOptionResource) read(ctx context.Context, timeout time.Duration, da
 	}
 
 	data.Tags = tags
-	data.RequestId = to.String(resp.ResponseContext.RequestId)
 	data.Id = to.String(dhcp.DhcpOptionsSetId)
 	data.DhcpOptionsSetId = to.String(dhcp.DhcpOptionsSetId)
 	data.DomainName = to.String(ptr.From(dhcp.DomainName))

--- a/internal/services/oapi/resource_dhcp_option_test.go
+++ b/internal/services/oapi/resource_dhcp_option_test.go
@@ -91,6 +91,25 @@ func TestAccOthers_DHCPOption_Migration(t *testing.T) {
 	})
 }
 
+func TestAccOthers_DHCPOption_CreateFailureKeepsState(t *testing.T) {
+	resourceName := "outscale_dhcp_option.foo"
+	invalidTagKey := strings.Repeat("a", 256)
+	tagValue := "testacc-dhcp-option"
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testacc.ProtoV6ProviderFactories(),
+		Steps: testacc.CreateFailureReplacementSteps(
+			resourceName,
+			testAccDHCPOptionConfigWithTag("foo", invalidTagKey, tagValue),
+			testAccDHCPOptionConfigWithTag("foo", "name", tagValue),
+			resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttrSet(resourceName, "dhcp_options_set_id"),
+				resource.TestCheckResourceAttr(resourceName, "tags.0.value", tagValue),
+			),
+		),
+	})
+}
+
 func testAccDHCPOptionalBasicConfig(ntpServers bool, logServers bool) string {
 	var ntp string
 	var log string
@@ -113,6 +132,20 @@ func testAccDHCPOptionalBasicConfig(ntpServers bool, logServers bool) string {
 		%s
 	}
 	`, ntp, log)
+}
+
+func testAccDHCPOptionConfigWithTag(resourceName, tagKey, tagValue string) string {
+	return fmt.Sprintf(`
+	resource "outscale_dhcp_option" %q {
+		domain_name         = "test.fr"
+		domain_name_servers = ["192.168.12.1"]
+
+		tags {
+			key   = %q
+			value = %q
+		}
+	}
+	`, resourceName, tagKey, tagValue)
 }
 
 func testAccOAPIDHCPOptionalWithNet(domainName string, domainServers []string) string {

--- a/internal/services/oapi/resource_flexible_gpu.go
+++ b/internal/services/oapi/resource_flexible_gpu.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -23,6 +24,12 @@ import (
 var (
 	_ resource.Resource              = &fgpuResource{}
 	_ resource.ResourceWithConfigure = &fgpuResource{}
+)
+
+const (
+	flexibleGpuErrCreate = "Unable to create Flexible GPU"
+	flexibleGpuErrUpdate = "Unable to update Flexible GPU"
+	flexibleGpuErrDelete = "Unable to delete Flexible GPU"
 )
 
 type GpuModel struct {
@@ -164,31 +171,24 @@ func (r *fgpuResource) Create(ctx context.Context, req resource.CreateRequest, r
 		createReq.Generation = data.Generation.ValueStringPointer()
 	}
 
-	createTimeout, diags := data.Timeouts.Create(ctx, CreateDefaultTimeout)
+	timeout, diags := data.Timeouts.Create(ctx, CreateDefaultTimeout)
 	if fwhelpers.CheckDiags(resp, diags) {
 		return
 	}
 
-	createResp, err := r.Client.CreateFlexibleGpu(ctx, createReq, options.WithRetryTimeout(createTimeout))
+	createResp, err := r.Client.CreateFlexibleGpu(ctx, createReq, options.WithRetryTimeout(timeout))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to Create Resource Net",
-			"Error: "+err.Error(),
-		)
+		resp.Diagnostics.AddError(flexibleGpuErrCreate, err.Error())
 		return
 	}
 	fGpu := ptr.From(createResp.FlexibleGpu)
 
 	data.FlexibleGpuId = to.String(fGpu.FlexibleGpuId)
-	data, err = read(ctx, r, data)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to set net state",
-			"Error: "+err.Error(),
-		)
-		return
-	}
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	data.Id = to.String(fGpu.FlexibleGpuId)
+
+	stateData := r.flatten(data, fGpu)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateData)...)
 }
 
 func (r *fgpuResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -200,16 +200,18 @@ func (r *fgpuResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 		return
 	}
 
-	data, err = read(ctx, r, data)
+	timeout, diags := data.Timeouts.Read(ctx, ReadDefaultTimeout)
+	if fwhelpers.CheckDiags(resp, diags) {
+		return
+	}
+
+	data, err = r.read(ctx, timeout, data)
 	if err != nil {
 		if errors.Is(err, ErrResourceEmpty) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(
-			"Unable to set net state",
-			"Error: "+err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -227,7 +229,7 @@ func (r *fgpuResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	updateTimeout, diags := planData.Timeouts.Update(ctx, UpdateDefaultTimeout)
+	timeout, diags := planData.Timeouts.Update(ctx, UpdateDefaultTimeout)
 	if fwhelpers.CheckDiags(resp, diags) {
 		return
 	}
@@ -236,22 +238,16 @@ func (r *fgpuResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		FlexibleGpuId:      resourceId.ValueString(),
 		DeleteOnVmDeletion: planData.DeleteOnVmDeletion.ValueBoolPointer(),
 	}
-	_, err = r.Client.UpdateFlexibleGpu(ctx, updateReq, options.WithRetryTimeout(updateTimeout))
+	_, err = r.Client.UpdateFlexibleGpu(ctx, updateReq, options.WithRetryTimeout(timeout))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to update Flexible GPU resource",
-			"Error: "+err.Error(),
-		)
+		resp.Diagnostics.AddError(flexibleGpuErrUpdate, err.Error())
 		return
 	}
 
 	planData.FlexibleGpuId = resourceId
-	data, err := read(ctx, r, planData)
+	data, err := r.read(ctx, timeout, planData)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to set Flexible GPU state",
-			"Error: "+err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -265,7 +261,7 @@ func (r *fgpuResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 		return
 	}
 
-	deleteTimeout, diags := data.Timeouts.Delete(ctx, DeleteDefaultTimeout)
+	timeout, diags := data.Timeouts.Delete(ctx, DeleteDefaultTimeout)
 	if fwhelpers.CheckDiags(resp, diags) {
 		return
 	}
@@ -273,16 +269,13 @@ func (r *fgpuResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 	delReq := osc.DeleteFlexibleGpuRequest{
 		FlexibleGpuId: data.FlexibleGpuId.ValueString(),
 	}
-	_, err := r.Client.DeleteFlexibleGpu(ctx, delReq, options.WithRetryTimeout(deleteTimeout))
+	_, err := r.Client.DeleteFlexibleGpu(ctx, delReq, options.WithRetryTimeout(timeout))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to Delete Flexible GPU resource",
-			"Error: "+err.Error(),
-		)
+		resp.Diagnostics.AddError(flexibleGpuErrDelete, err.Error())
 	}
 }
 
-func read(ctx context.Context, r *fgpuResource, data GpuModel) (GpuModel, error) {
+func (r *fgpuResource) read(ctx context.Context, timeout time.Duration, data GpuModel) (GpuModel, error) {
 	netFilters := osc.FiltersFlexibleGpu{
 		FlexibleGpuIds: &[]string{data.FlexibleGpuId.ValueString()},
 	}
@@ -290,11 +283,7 @@ func read(ctx context.Context, r *fgpuResource, data GpuModel) (GpuModel, error)
 		Filters: &netFilters,
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, ReadDefaultTimeout)
-	if diags.HasError() {
-		return data, fmt.Errorf("unable to parse 'flexible_gpu' read timeout value: %v", diags.Errors())
-	}
-	readResp, err := r.Client.ReadFlexibleGpus(ctx, readReq, options.WithRetryTimeout(readTimeout))
+	readResp, err := r.Client.ReadFlexibleGpus(ctx, readReq, options.WithRetryTimeout(timeout))
 	if err != nil {
 		return data, err
 	}
@@ -303,6 +292,11 @@ func read(ctx context.Context, r *fgpuResource, data GpuModel) (GpuModel, error)
 		return data, ErrResourceEmpty
 	}
 	fgpu := (*readResp.FlexibleGpus)[0]
+
+	return r.flatten(data, fgpu), nil
+}
+
+func (r *fgpuResource) flatten(data GpuModel, fgpu osc.FlexibleGpu) GpuModel {
 	data.DeleteOnVmDeletion = to.Bool(fgpu.DeleteOnVmDeletion)
 	data.FlexibleGpuId = to.String(fgpu.FlexibleGpuId)
 	data.SubregionName = to.String(fgpu.SubregionName)
@@ -312,5 +306,5 @@ func read(ctx context.Context, r *fgpuResource, data GpuModel) (GpuModel, error)
 	data.State = to.String(fgpu.State)
 	data.VmId = to.String(ptr.From(fgpu.VmId))
 
-	return data, nil
+	return data
 }

--- a/internal/services/oapi/resource_flexible_gpu_link.go
+++ b/internal/services/oapi/resource_flexible_gpu_link.go
@@ -21,6 +21,7 @@ import (
 	"github.com/outscale/osc-sdk-go/v3/pkg/osc"
 	"github.com/outscale/terraform-provider-outscale/internal/client"
 	"github.com/outscale/terraform-provider-outscale/internal/framework/fwhelpers"
+	"github.com/outscale/terraform-provider-outscale/internal/framework/fwhelpers/from"
 	"github.com/outscale/terraform-provider-outscale/internal/framework/fwhelpers/to"
 	"github.com/samber/lo"
 )
@@ -31,11 +32,10 @@ var (
 )
 
 const (
-	fgpuLinkCreateTimeout = 5 * time.Minute
+	fgpuLinktimeout = 5 * time.Minute
 
 	fgpuLinkErrLink             = "Unable to link fGPU"
 	fgpuLinkErrUnlink           = "Unable to unlink fGPU"
-	fgpuLinkErrState            = "Unable to set fGPU resource state"
 	fgpuLinkErrShutdownBehavior = "Unable to change VM shutdown behavior"
 )
 
@@ -142,7 +142,7 @@ func (r *fgpuLinkResource) Create(ctx context.Context, req resource.CreateReques
 	var data fgpuLinkModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
 
-	createTimeout, diag := data.Timeouts.Create(ctx, fgpuLinkCreateTimeout)
+	timeout, diag := data.Timeouts.Create(ctx, fgpuLinktimeout)
 	if fwhelpers.CheckDiags(resp, diag) {
 		return
 	}
@@ -158,7 +158,7 @@ func (r *fgpuLinkResource) Create(ctx context.Context, req resource.CreateReques
 			VmId:          data.VmId.ValueString(),
 		}
 
-		_, err := r.Client.LinkFlexibleGpu(ctx, createReq, options.WithRetryTimeout(createTimeout))
+		_, err := r.Client.LinkFlexibleGpu(ctx, createReq, options.WithRetryTimeout(timeout))
 		if err != nil {
 			resp.Diagnostics.AddError(
 				fgpuLinkErrLink,
@@ -166,11 +166,25 @@ func (r *fgpuLinkResource) Create(ctx context.Context, req resource.CreateReques
 			)
 			return
 		}
+		// The API response does not contain enough information to set the state directly, which would cause an error.
+		// The next read will fill the state
 	}
 
 	data.Id = to.String(id.UniqueId())
+	stateData, err := r.read(ctx, timeout, data)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			errSetTerraformState,
+			err.Error(),
+		)
+		return
+	}
+	diag = resp.State.Set(ctx, &stateData)
+	if fwhelpers.CheckDiags(resp, diag) {
+		return
+	}
 
-	err := r.changeShutdownBehavior(ctx, data.VmId.ValueString(), createTimeout)
+	err = r.changeShutdownBehavior(ctx, data.VmId.ValueString(), timeout)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			fgpuLinkErrShutdownBehavior,
@@ -178,38 +192,24 @@ func (r *fgpuLinkResource) Create(ctx context.Context, req resource.CreateReques
 		)
 		return
 	}
-
-	stateData, err := r.read(ctx, createTimeout, data)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			fgpuLinkErrState,
-			err.Error(),
-		)
-		return
-	}
-
-	resp.Diagnostics.Append(resp.State.Set(ctx, &stateData)...)
 }
 
 func (r *fgpuLinkResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var data fgpuLinkModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
 
-	readTimeout, diag := data.Timeouts.Read(ctx, ReadDefaultTimeout)
+	timeout, diag := data.Timeouts.Read(ctx, ReadDefaultTimeout)
 	if fwhelpers.CheckDiags(resp, diag) {
 		return
 	}
 
-	stateData, err := r.read(ctx, readTimeout, data)
+	stateData, err := r.read(ctx, timeout, data)
 	if err != nil {
 		if errors.Is(err, ErrResourceEmpty) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(
-			fgpuLinkErrState,
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
@@ -278,10 +278,7 @@ func (r *fgpuLinkResource) Update(ctx context.Context, req resource.UpdateReques
 
 	data, err := r.read(ctx, timeout, planData)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			fgpuLinkErrState,
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
@@ -347,7 +344,7 @@ func (r *fgpuLinkResource) read(ctx context.Context, timeout time.Duration, data
 	})
 	idsSet, diag := to.Set(ctx, gpuIds)
 	if diag.HasError() {
-		return data, fmt.Errorf("%v", diag.Errors())
+		return data, from.Diag(diag)
 	}
 
 	data.FlexibleGpuIds = idsSet

--- a/internal/services/oapi/resource_internet_service.go
+++ b/internal/services/oapi/resource_internet_service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -17,6 +18,7 @@ import (
 	"github.com/outscale/osc-sdk-go/v3/pkg/osc"
 	"github.com/outscale/terraform-provider-outscale/internal/client"
 	"github.com/outscale/terraform-provider-outscale/internal/framework/fwhelpers"
+	"github.com/outscale/terraform-provider-outscale/internal/framework/fwhelpers/from"
 	"github.com/outscale/terraform-provider-outscale/internal/framework/fwhelpers/to"
 )
 
@@ -25,6 +27,11 @@ var (
 	_ resource.ResourceWithConfigure   = &resourceInternetService{}
 	_ resource.ResourceWithImportState = &resourceInternetService{}
 	_ resource.ResourceWithModifyPlan  = &resourceInternetService{}
+)
+
+const (
+	internetServiceErrCreate = "Unable to create Internet Service"
+	internetServiceErrDelete = "Unable to delete Internet Service"
 )
 
 type InternetServiceModel struct {
@@ -147,41 +154,44 @@ func (r *resourceInternetService) Create(ctx context.Context, req resource.Creat
 		return
 	}
 
-	createTimeout, diags := data.Timeouts.Create(ctx, CreateDefaultTimeout)
+	timeout, diags := data.Timeouts.Create(ctx, CreateDefaultTimeout)
 	if fwhelpers.CheckDiags(resp, diags) {
 		return
 	}
 
 	createReq := osc.CreateInternetServiceRequest{}
 
-	createResp, err := r.Client.CreateInternetService(ctx, createReq, options.WithRetryTimeout(createTimeout))
+	createResp, err := r.Client.CreateInternetService(ctx, createReq, options.WithRetryTimeout(timeout))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to create Internet Service resource.",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(internetServiceErrCreate, err.Error())
 		return
 	}
-	data.RequestId = to.String(createResp.ResponseContext.RequestId)
 	internetService := ptr.From(createResp.InternetService)
+	data.RequestId = to.String(createResp.ResponseContext.RequestId)
+	data.InternetServiceId = to.String(internetService.InternetServiceId)
+	data.Id = to.String(internetService.InternetServiceId)
 
-	diag := createOAPITagsFW(ctx, r.Client, createTimeout, data.Tags, internetService.InternetServiceId)
+	stateData, err := r.flatten(ctx, data, internetService)
+	if err != nil {
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
+		return
+	}
+	diags = resp.State.Set(ctx, &stateData)
+	if fwhelpers.CheckDiags(resp, diags) {
+		return
+	}
+
+	diag := createOAPITagsFW(ctx, r.Client, timeout, data.Tags, internetService.InternetServiceId)
 	if fwhelpers.CheckDiags(resp, diag) {
 		return
 	}
 
-	data.InternetServiceId = to.String(internetService.InternetServiceId)
-	data.Id = to.String(internetService.InternetServiceId)
-
-	data, err = r.read(ctx, data)
+	stateData, err = r.read(ctx, timeout, data)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to set Internet Service state.",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateData)...)
 }
 
 func (r *resourceInternetService) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -192,16 +202,18 @@ func (r *resourceInternetService) Read(ctx context.Context, req resource.ReadReq
 		return
 	}
 
-	data, err := r.read(ctx, data)
+	timeout, diags := data.Timeouts.Read(ctx, ReadDefaultTimeout)
+	if fwhelpers.CheckDiags(resp, diags) {
+		return
+	}
+
+	data, err := r.read(ctx, timeout, data)
 	if err != nil {
 		if errors.Is(err, ErrResourceEmpty) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(
-			"Unable to set Internet Service API response values.",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -229,12 +241,9 @@ func (r *resourceInternetService) Update(ctx context.Context, req resource.Updat
 		return
 	}
 
-	stateData, err := r.read(ctx, planData)
+	stateData, err := r.read(ctx, timeout, planData)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to set Internet Service state.",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
@@ -249,7 +258,7 @@ func (r *resourceInternetService) Delete(ctx context.Context, req resource.Delet
 		return
 	}
 
-	deleteTimeout, diags := data.Timeouts.Delete(ctx, DeleteDefaultTimeout)
+	timeout, diags := data.Timeouts.Delete(ctx, DeleteDefaultTimeout)
 	if fwhelpers.CheckDiags(resp, diags) {
 		return
 	}
@@ -258,16 +267,13 @@ func (r *resourceInternetService) Delete(ctx context.Context, req resource.Delet
 		InternetServiceId: data.InternetServiceId.ValueString(),
 	}
 
-	_, err := r.Client.DeleteInternetService(ctx, delReq, options.WithRetryTimeout(deleteTimeout))
+	_, err := r.Client.DeleteInternetService(ctx, delReq, options.WithRetryTimeout(timeout))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to delete Internet Service.",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(internetServiceErrDelete, err.Error())
 	}
 }
 
-func (r *resourceInternetService) read(ctx context.Context, data InternetServiceModel) (InternetServiceModel, error) {
+func (r *resourceInternetService) read(ctx context.Context, timeout time.Duration, data InternetServiceModel) (InternetServiceModel, error) {
 	internetServiceFilters := osc.FiltersInternetService{
 		InternetServiceIds: &[]string{data.InternetServiceId.ValueString()},
 	}
@@ -275,12 +281,7 @@ func (r *resourceInternetService) read(ctx context.Context, data InternetService
 		Filters: &internetServiceFilters,
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, ReadDefaultTimeout)
-	if diags.HasError() {
-		return data, fmt.Errorf("unable to parse 'internet service' read timeout value: %v", diags.Errors())
-	}
-
-	readResp, err := r.Client.ReadInternetServices(ctx, readReq, options.WithRetryTimeout(readTimeout))
+	readResp, err := r.Client.ReadInternetServices(ctx, readReq, options.WithRetryTimeout(timeout))
 	if err != nil {
 		return data, err
 	}
@@ -289,13 +290,17 @@ func (r *resourceInternetService) read(ctx context.Context, data InternetService
 	}
 
 	internetService := (*readResp.InternetServices)[0]
+	data.RequestId = to.String(readResp.ResponseContext.RequestId)
 
+	return r.flatten(ctx, data, internetService)
+}
+
+func (r *resourceInternetService) flatten(ctx context.Context, data InternetServiceModel, internetService osc.InternetService) (InternetServiceModel, error) {
 	tags, diag := flattenOAPITagsFW(ctx, internetService.Tags)
 	if diag.HasError() {
-		return data, fmt.Errorf("unable to flatten tags: %v", diags.Errors())
+		return data, from.Diag(diag)
 	}
 	data.Tags = tags
-	data.RequestId = to.String(readResp.ResponseContext.RequestId)
 	data.NetId = to.String(internetService.NetId)
 	data.State = to.String(internetService.State)
 	data.Id = to.String(internetService.InternetServiceId)

--- a/internal/services/oapi/resource_internet_service_link.go
+++ b/internal/services/oapi/resource_internet_service_link.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -18,6 +19,7 @@ import (
 	"github.com/outscale/osc-sdk-go/v3/pkg/osc"
 	"github.com/outscale/terraform-provider-outscale/internal/client"
 	"github.com/outscale/terraform-provider-outscale/internal/framework/fwhelpers"
+	"github.com/outscale/terraform-provider-outscale/internal/framework/fwhelpers/from"
 	"github.com/outscale/terraform-provider-outscale/internal/framework/fwhelpers/to"
 	"github.com/outscale/terraform-provider-outscale/internal/services/oapi/oapihelpers"
 )
@@ -27,6 +29,14 @@ var (
 	_ resource.ResourceWithConfigure   = &resourceInternetServiceLink{}
 	_ resource.ResourceWithImportState = &resourceInternetServiceLink{}
 	_ resource.ResourceWithModifyPlan  = &resourceInternetServiceLink{}
+)
+
+const (
+	internetServiceLinkErrCreate    = "Unable to link Internet Service"
+	internetServiceLinkErrDelete    = "Unable to unlink Internet Service"
+	internetServiceLinkErrReadNics  = "Unable to read NICs linked to Internet Service net"
+	internetServiceLinkErrUnmapIPs  = "Unable to unlink Public IPs from Internet Service net NICs"
+	internetServiceLinkErrRetryLink = "Unable to unlink Internet Service after unmapping Public IPs"
 )
 
 type InternetServiceLinkModel struct {
@@ -149,7 +159,7 @@ func (r *resourceInternetServiceLink) Create(ctx context.Context, req resource.C
 		return
 	}
 
-	createTimeout, diags := data.Timeouts.Create(ctx, CreateDefaultTimeout)
+	timeout, diags := data.Timeouts.Create(ctx, CreateDefaultTimeout)
 	if fwhelpers.CheckDiags(resp, diags) {
 		return
 	}
@@ -159,28 +169,24 @@ func (r *resourceInternetServiceLink) Create(ctx context.Context, req resource.C
 		NetId:             data.NetId.ValueString(),
 	}
 
-	createResp, err := r.Client.LinkInternetService(ctx, createReq, options.WithRetryTimeout(createTimeout))
+	createResp, err := r.Client.LinkInternetService(ctx, createReq, options.WithRetryTimeout(timeout))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to link Internet Service resource.",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(internetServiceLinkErrCreate, err.Error())
 		return
 	}
 	data.RequestId = to.String(createResp.ResponseContext.RequestId)
 
 	data.InternetServiceId = to.String(data.InternetServiceId.ValueString())
 	data.Id = to.String(data.InternetServiceId.ValueString())
+	// The API response does not contain enough information to set the state directly, which would cause an error.
+	// The next read will fill the state
 
-	data, err = setInternetServiceLinkState(ctx, r, data)
+	stateData, err := r.read(ctx, timeout, data)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to set Internet Service Link state.",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateData)...)
 }
 
 func (r *resourceInternetServiceLink) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -191,19 +197,21 @@ func (r *resourceInternetServiceLink) Read(ctx context.Context, req resource.Rea
 		return
 	}
 
-	data, err := setInternetServiceLinkState(ctx, r, data)
+	timeout, diags := data.Timeouts.Read(ctx, ReadDefaultTimeout)
+	if fwhelpers.CheckDiags(resp, diags) {
+		return
+	}
+
+	stateData, err := r.read(ctx, timeout, data)
 	if err != nil {
 		if errors.Is(err, ErrResourceEmpty) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(
-			"Unable to set Internet Service API response values.",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateData)...)
 }
 
 func (r *resourceInternetServiceLink) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
@@ -217,7 +225,7 @@ func (r *resourceInternetServiceLink) Delete(ctx context.Context, req resource.D
 		return
 	}
 
-	deleteTimeout, diags := data.Timeouts.Delete(ctx, DeleteDefaultTimeout)
+	timeout, diags := data.Timeouts.Delete(ctx, DeleteDefaultTimeout)
 	if fwhelpers.CheckDiags(resp, diags) {
 		return
 	}
@@ -228,7 +236,7 @@ func (r *resourceInternetServiceLink) Delete(ctx context.Context, req resource.D
 	}
 
 	var hasIPs, hasLBU bool
-	_, err := r.Client.UnlinkInternetService(ctx, unlinkReq, options.WithRetryTimeout(deleteTimeout))
+	_, err := r.Client.UnlinkInternetService(ctx, unlinkReq, options.WithRetryTimeout(timeout))
 	if err != nil {
 		oscErr := oapihelpers.GetError(err)
 		switch oscErr.Code {
@@ -240,10 +248,7 @@ func (r *resourceInternetServiceLink) Delete(ctx context.Context, req resource.D
 			// 409 with code 1005 is returned when the Net of the Internet Service has a Load Balancer
 			hasLBU = true
 		default:
-			resp.Diagnostics.AddError(
-				"Unable to unlink Internet Service resource.",
-				err.Error(),
-			)
+			resp.Diagnostics.AddError(internetServiceLinkErrDelete, err.Error())
 			return
 		}
 	}
@@ -254,12 +259,9 @@ func (r *resourceInternetServiceLink) Delete(ctx context.Context, req resource.D
 			Filters: &osc.FiltersNic{
 				NetIds: &[]string{data.NetId.ValueString()},
 			},
-		}, options.WithRetryTimeout(deleteTimeout))
+		}, options.WithRetryTimeout(timeout))
 		if err != nil {
-			resp.Diagnostics.AddError(
-				"Unable to get Nics linked to the net of the Internet Service.",
-				err.Error(),
-			)
+			resp.Diagnostics.AddError(internetServiceLinkErrReadNics, err.Error())
 		}
 		if len(ptr.From(respNics.Nics)) > 0 {
 			for _, nic := range ptr.From(respNics.Nics) {
@@ -272,31 +274,25 @@ func (r *resourceInternetServiceLink) Delete(ctx context.Context, req resource.D
 		for _, ip := range publicIps {
 			_, err := r.Client.UnlinkPublicIp(ctx, osc.UnlinkPublicIpRequest{
 				LinkPublicIpId: &ip.LinkPublicIpId,
-			}, options.WithRetryTimeout(deleteTimeout))
+			}, options.WithRetryTimeout(timeout))
 			if err != nil {
 				switch {
 				case osc.HasErrorCode(err, []string{"5026"}):
 					// 400 with code 5026 is returned when Public IP is already destroyed
 					// In this case, we can skip it
 				default:
-					resp.Diagnostics.AddError(
-						"Unable to unlink Public IP from the NICs linked to the Net of the Internet Service.",
-						err.Error(),
-					)
+					resp.Diagnostics.AddError(internetServiceLinkErrUnmapIPs, err.Error())
 				}
 			}
 		}
 
-		_, err = r.Client.UnlinkInternetService(ctx, unlinkReq, options.WithRetryTimeout(deleteTimeout))
+		_, err = r.Client.UnlinkInternetService(ctx, unlinkReq, options.WithRetryTimeout(timeout))
 		if err != nil {
 			oscErr := oapihelpers.GetError(err)
 			// 424 with code 1007 is returned when Internet Service is already unlinked
 			// In this case, the link resource can be destroyed
 			if oscErr.Code != "1007" {
-				resp.Diagnostics.AddError(
-					"Unable to unlink Internet Service resource after unmapping Public IPs.",
-					err.Error(),
-				)
+				resp.Diagnostics.AddError(internetServiceLinkErrRetryLink, err.Error())
 				return
 			}
 		}
@@ -309,18 +305,15 @@ func (r *resourceInternetServiceLink) Delete(ctx context.Context, req resource.D
 		// Checking only for specific states would miss cases like a concurrent
 		// backend vms unlink putting the LBU in "reloading" state (like in TF-2 integration test)
 		_, err := oapihelpers.RetryOnCodes(ctx, []string{"1005"}, func() (resp any, err error) {
-			return r.Client.UnlinkInternetService(ctx, unlinkReq, options.WithRetryTimeout(deleteTimeout))
-		}, deleteTimeout)
+			return r.Client.UnlinkInternetService(ctx, unlinkReq, options.WithRetryTimeout(timeout))
+		}, timeout)
 		if err != nil {
-			resp.Diagnostics.AddError(
-				"Unable to unlink Internet Service.",
-				err.Error(),
-			)
+			resp.Diagnostics.AddError(internetServiceLinkErrDelete, err.Error())
 		}
 	}
 }
 
-func setInternetServiceLinkState(ctx context.Context, r *resourceInternetServiceLink, data InternetServiceLinkModel) (InternetServiceLinkModel, error) {
+func (r *resourceInternetServiceLink) read(ctx context.Context, timeout time.Duration, data InternetServiceLinkModel) (InternetServiceLinkModel, error) {
 	internetServiceFilters := osc.FiltersInternetService{
 		InternetServiceIds: &[]string{data.InternetServiceId.ValueString()},
 	}
@@ -328,12 +321,7 @@ func setInternetServiceLinkState(ctx context.Context, r *resourceInternetService
 		Filters: &internetServiceFilters,
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, ReadDefaultTimeout)
-	if diags.HasError() {
-		return data, fmt.Errorf("unable to parse 'internet service' read timeout value: %v", diags.Errors())
-	}
-
-	readResp, err := r.Client.ReadInternetServices(ctx, readReq, options.WithRetryTimeout(readTimeout))
+	readResp, err := r.Client.ReadInternetServices(ctx, readReq, options.WithRetryTimeout(timeout))
 	if err != nil {
 		return data, err
 	}
@@ -345,7 +333,7 @@ func setInternetServiceLinkState(ctx context.Context, r *resourceInternetService
 
 	tags, diag := flattenOAPIComputedTagsFW(ctx, internetService.Tags)
 	if diag.HasError() {
-		return data, fmt.Errorf("unable to convert flatten tags: %v", diags.Errors())
+		return data, from.Diag(diag)
 	}
 	data.Tags = tags
 

--- a/internal/services/oapi/resource_internet_service_test.go
+++ b/internal/services/oapi/resource_internet_service_test.go
@@ -1,6 +1,7 @@
 package oapi_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -29,12 +30,35 @@ func TestAccOthers_InternetService_Migration(t *testing.T) {
 	})
 }
 
+func TestAccOthers_InternetService_CreateFailureKeepsState(t *testing.T) {
+	resourceName := "outscale_internet_service.internet_service"
+	invalidTagKey := strings.Repeat("a", 256)
+	tagValue := "testacc-internet-service"
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testacc.ProtoV6ProviderFactories(),
+		Steps: testacc.CreateFailureReplacementSteps(
+			resourceName,
+			testAccOutscaleInternetServiceConfigWithTag(invalidTagKey, tagValue),
+			testAccOutscaleInternetServiceConfigWithTag("Name", tagValue),
+			resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttrSet(resourceName, "internet_service_id"),
+				resource.TestCheckResourceAttr(resourceName, "tags.0.value", tagValue),
+			),
+		),
+	})
+}
+
 func testAccOutscaleInternetServiceConfig() string {
+	return testAccOutscaleInternetServiceConfigWithTag("Name", "testacc-internet-service")
+}
+
+func testAccOutscaleInternetServiceConfigWithTag(tagKey, tagValue string) string {
 	return `
 		resource "outscale_internet_service" "internet_service" {
 			tags {
-				key = "Name"
-				value = "testacc-internet-service"
+				key = "` + tagKey + `"
+				value = "` + tagValue + `"
 			}
 		}
 	`

--- a/internal/services/oapi/resource_keypair.go
+++ b/internal/services/oapi/resource_keypair.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -17,6 +18,7 @@ import (
 	"github.com/outscale/osc-sdk-go/v3/pkg/osc"
 	"github.com/outscale/terraform-provider-outscale/internal/client"
 	"github.com/outscale/terraform-provider-outscale/internal/framework/fwhelpers"
+	"github.com/outscale/terraform-provider-outscale/internal/framework/fwhelpers/from"
 	"github.com/outscale/terraform-provider-outscale/internal/framework/fwhelpers/to"
 )
 
@@ -24,6 +26,11 @@ var (
 	_ resource.Resource               = &resourceKeypair{}
 	_ resource.ResourceWithConfigure  = &resourceKeypair{}
 	_ resource.ResourceWithModifyPlan = &resourceKeypair{}
+)
+
+const (
+	keypairErrCreate = "Unable to create Keypair"
+	keypairErrDelete = "Unable to delete Keypair"
 )
 
 type KeypairModel struct {
@@ -39,8 +46,12 @@ type KeypairModel struct {
 	TagsModel
 }
 
-type resourceKeypair struct {
+type keypairCommon struct {
 	Client *osc.Client
+}
+
+type resourceKeypair struct {
+	keypairCommon
 }
 
 func NewResourceKeypair() resource.Resource {
@@ -158,7 +169,7 @@ func (r *resourceKeypair) Create(ctx context.Context, req resource.CreateRequest
 		return
 	}
 
-	createTimeout, diags := data.Timeouts.Create(ctx, CreateDefaultTimeout)
+	timeout, diags := data.Timeouts.Create(ctx, CreateDefaultTimeout)
 	if fwhelpers.CheckDiags(resp, diags) {
 		return
 	}
@@ -170,12 +181,9 @@ func (r *resourceKeypair) Create(ctx context.Context, req resource.CreateRequest
 		createReq.PublicKey = data.PublicKey.ValueStringPointer()
 	}
 
-	createResp, err := r.Client.CreateKeypair(ctx, createReq, options.WithRetryTimeout(createTimeout))
+	createResp, err := r.Client.CreateKeypair(ctx, createReq, options.WithRetryTimeout(timeout))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to create keypair resource",
-			"Error: "+err.Error(),
-		)
+		resp.Diagnostics.AddError(keypairErrCreate, err.Error())
 		return
 	}
 	data.RequestId = to.String(createResp.ResponseContext.RequestId)
@@ -187,22 +195,25 @@ func (r *resourceKeypair) Create(ctx context.Context, req resource.CreateRequest
 		data.PublicKey = to.String(createReq.PublicKey)
 	}
 
-	diag := createOAPITagsFW(ctx, r.Client, createTimeout, data.Tags, *keypair.KeypairId)
+	stateData := r.flattenCreate(data, keypair)
+	diag := resp.State.Set(ctx, &stateData)
+	if fwhelpers.CheckDiags(resp, diag) {
+		return
+	}
+
+	diag = createOAPITagsFW(ctx, r.Client, timeout, data.Tags, *keypair.KeypairId)
 	if fwhelpers.CheckDiags(resp, diag) {
 		return
 	}
 
 	data.PrivateKey = to.String(ptr.From(keypair.PrivateKey))
 
-	err = setKeypairState(ctx, r, &data)
+	stateData, err = r.read(ctx, timeout, data)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to set keypair state",
-			"Error: "+err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateData)...)
 }
 
 func (r *resourceKeypair) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -213,19 +224,22 @@ func (r *resourceKeypair) Read(ctx context.Context, req resource.ReadRequest, re
 		return
 	}
 
-	err := setKeypairState(ctx, r, &data)
+	timeout, diags := data.Timeouts.Read(ctx, ReadDefaultTimeout)
+	if fwhelpers.CheckDiags(resp, diags) {
+		return
+	}
+
+	stateData, err := r.read(ctx, timeout, data)
 	if err != nil {
 		if errors.Is(err, ErrResourceEmpty) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(
-			"Unable to set keypair API response values.",
-			"Error: "+err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateData)...)
 }
 
 func (r *resourceKeypair) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
@@ -247,12 +261,9 @@ func (r *resourceKeypair) Update(ctx context.Context, req resource.UpdateRequest
 	}
 
 	stateData.Timeouts = planData.Timeouts
-	err := setKeypairState(ctx, r, &stateData)
+	stateData, err := r.read(ctx, timeout, stateData)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to set keypair state after tags updating.",
-			"Error: "+err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
@@ -267,7 +278,7 @@ func (r *resourceKeypair) Delete(ctx context.Context, req resource.DeleteRequest
 		return
 	}
 
-	deleteTimeout, diags := data.Timeouts.Delete(ctx, DeleteDefaultTimeout)
+	timeout, diags := data.Timeouts.Delete(ctx, DeleteDefaultTimeout)
 	if fwhelpers.CheckDiags(resp, diags) {
 		return
 	}
@@ -276,40 +287,32 @@ func (r *resourceKeypair) Delete(ctx context.Context, req resource.DeleteRequest
 		KeypairId: data.KeypairId.ValueStringPointer(),
 	}
 
-	_, err := r.Client.DeleteKeypair(ctx, delReq, options.WithRetryTimeout(deleteTimeout))
+	_, err := r.Client.DeleteKeypair(ctx, delReq, options.WithRetryTimeout(timeout))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to Delete keypair",
-			"Error: "+err.Error(),
-		)
+		resp.Diagnostics.AddError(keypairErrDelete, err.Error())
 	}
 }
 
-func setKeypairState(ctx context.Context, r *resourceKeypair, data *KeypairModel) error {
+func (r *keypairCommon) read(ctx context.Context, timeout time.Duration, data KeypairModel) (KeypairModel, error) {
 	keypairFilters := osc.FiltersKeypair{
 		KeypairNames: &[]string{data.KeypairName.ValueString()},
-	}
-
-	readTimeout, diags := data.Timeouts.Read(ctx, ReadDefaultTimeout)
-	if diags.HasError() {
-		return fmt.Errorf("unable to parse 'keypair' read timeout value: %v", diags.Errors())
 	}
 
 	readReq := osc.ReadKeypairsRequest{
 		Filters: &keypairFilters,
 	}
-	readResp, err := r.Client.ReadKeypairs(ctx, readReq, options.WithRetryTimeout(readTimeout))
+	readResp, err := r.Client.ReadKeypairs(ctx, readReq, options.WithRetryTimeout(timeout))
 	if err != nil {
-		return err
+		return data, err
 	}
 	if readResp.Keypairs == nil || len(*readResp.Keypairs) == 0 {
-		return ErrResourceEmpty
+		return data, ErrResourceEmpty
 	}
 
 	keypair := (*readResp.Keypairs)[0]
 	tags, diag := flattenOAPITagsFW(ctx, ptr.From(keypair.Tags))
 	if diag.HasError() {
-		return fmt.Errorf("unable to flatten tags: %v", diags.Errors())
+		return data, from.Diag(diag)
 	}
 	data.Tags = tags
 	data.KeypairFingerprint = to.String(ptr.From(keypair.KeypairFingerprint))
@@ -317,5 +320,15 @@ func setKeypairState(ctx context.Context, r *resourceKeypair, data *KeypairModel
 	data.KeypairType = to.String(ptr.From(keypair.KeypairType))
 	data.KeypairId = to.String(keypair.KeypairId)
 
-	return nil
+	return data, nil
+}
+
+func (r *keypairCommon) flattenCreate(data KeypairModel, keypair osc.KeypairCreated) KeypairModel {
+	data.KeypairFingerprint = to.String(ptr.From(keypair.KeypairFingerprint))
+	data.KeypairId = to.String(keypair.KeypairId)
+	data.KeypairName = to.String(ptr.From(keypair.KeypairName))
+	data.KeypairType = to.String(ptr.From(keypair.KeypairType))
+	data.PrivateKey = to.String(ptr.From(keypair.PrivateKey))
+
+	return data
 }

--- a/internal/services/oapi/resource_keypair_test.go
+++ b/internal/services/oapi/resource_keypair_test.go
@@ -2,6 +2,7 @@ package oapi_test
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -78,6 +79,26 @@ func TestAccOthers_keypairUpdateTags(t *testing.T) {
 	})
 }
 
+func TestAccOthers_keypair_CreateFailureKeepsState(t *testing.T) {
+	resourceName := "outscale_keypair.update_keypair"
+	keypairName := acctest.RandomWithPrefix("basic-keypair")
+	invalidTagKey := strings.Repeat("a", 256)
+	tagValue := "testacc-keypair"
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testacc.ProtoV6ProviderFactories(),
+		Steps: testacc.CreateFailureReplacementSteps(
+			resourceName,
+			testAcckeypairUpdateTagsWithKey(keypairName, invalidTagKey, tagValue),
+			testAcckeypairUpdateTags(keypairName, tagValue),
+			resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttrSet(resourceName, "keypair_id"),
+				resource.TestCheckResourceAttr(resourceName, "tags.0.value", tagValue),
+			),
+		),
+	})
+}
+
 func testAcckeypairBasicConfig(keypair string) string {
 	return fmt.Sprintf(`
 			resource "outscale_keypair" "basic_keypair" {
@@ -87,13 +108,17 @@ func testAcckeypairBasicConfig(keypair string) string {
 }
 
 func testAcckeypairUpdateTags(keypairName, value string) string {
+	return testAcckeypairUpdateTagsWithKey(keypairName, "name", value)
+}
+
+func testAcckeypairUpdateTagsWithKey(keypairName, key, value string) string {
 	return fmt.Sprintf(`
 		resource "outscale_keypair" "update_keypair" {
 			keypair_name = "%[1]s"
 			tags {
-				key   = "name"
-				value = "%[2]s"
+				key   = "%[2]s"
+				value = "%[3]s"
 			}
 		}
-		`, keypairName, value)
+		`, keypairName, key, value)
 }

--- a/internal/services/oapi/resource_load_balancer_vms.go
+++ b/internal/services/oapi/resource_load_balancer_vms.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
@@ -20,6 +21,7 @@ import (
 	"github.com/outscale/osc-sdk-go/v3/pkg/osc"
 	"github.com/outscale/terraform-provider-outscale/internal/client"
 	"github.com/outscale/terraform-provider-outscale/internal/framework/fwhelpers"
+	"github.com/outscale/terraform-provider-outscale/internal/framework/fwhelpers/from"
 	"github.com/outscale/terraform-provider-outscale/internal/framework/fwhelpers/to"
 )
 
@@ -29,7 +31,16 @@ var (
 	_ resource.ResourceWithModifyPlan = &resourceLbuVms{}
 )
 
-type LbuBackendVmsModel struct {
+const (
+	lbuVmsErrCreate = "Unable to create Load Balancer backends"
+	lbuVmsErrUpdate = "Unable to update Load Balancer backends"
+	lbuVmsErrDelete = "Unable to delete Load Balancer backends"
+	lbuVmsErrWait   = "Unable to wait for Load Balancer state"
+	lbuVmsErrRemove = "Unable to remove Load Balancer backends"
+	lbuVmsErrAdd    = "Unable to add Load Balancer backends"
+)
+
+type lbuBackendVmsModel struct {
 	LoadBalancerName types.String   `tfsdk:"load_balancer_name"`
 	BackendVmIds     types.Set      `tfsdk:"backend_vm_ids"`
 	BackendIps       types.Set      `tfsdk:"backend_ips"`
@@ -63,7 +74,7 @@ func (r *resourceLbuVms) Configure(_ context.Context, req resource.ConfigureRequ
 }
 
 func (r *resourceLbuVms) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
-	var data LbuBackendVmsModel
+	var data lbuBackendVmsModel
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -141,14 +152,14 @@ func (r *resourceLbuVms) Schema(ctx context.Context, _ resource.SchemaRequest, r
 }
 
 func (r *resourceLbuVms) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	var data LbuBackendVmsModel
+	var data lbuBackendVmsModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	createTimeout, diags := data.Timeouts.Create(ctx, CreateDefaultTimeout)
+	timeout, diags := data.Timeouts.Create(ctx, CreateDefaultTimeout)
 	if fwhelpers.CheckDiags(resp, diags) {
 		return
 	}
@@ -169,128 +180,126 @@ func (r *resourceLbuVms) Create(ctx context.Context, req resource.CreateRequest,
 		createReq.BackendIps = &listVmsIps
 	}
 
-	createResp, err := r.Client.LinkLoadBalancerBackendMachines(ctx, createReq, options.WithRetryTimeout(createTimeout))
+	createResp, err := r.Client.LinkLoadBalancerBackendMachines(ctx, createReq, options.WithRetryTimeout(timeout))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to create LBU Backend_vms resource",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(lbuVmsErrCreate, err.Error())
 		return
 	}
 	data.RequestId = to.String(*createResp.ResponseContext.RequestId)
 	data.Id = to.String(lbuName)
 
-	if err = waitForLbuActive(ctx, r.Client, lbuName, createTimeout); err != nil {
-		resp.Diagnostics.AddError(
-			"Error waiting for load balancer to become active after linking backends",
-			err.Error(),
-		)
+	// LinkLoadBalancerBackendMachines response does not return the LBU object, a read is required to store the initial state
+	stateData, err := r.read(ctx, timeout, data)
+	if err != nil {
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
+		return
+	}
+	diags = resp.State.Set(ctx, &stateData)
+	if fwhelpers.CheckDiags(resp, diags) {
 		return
 	}
 
-	err = setLbuBackendState(ctx, r, &data)
+	lbu, err := waitForLbuActive(ctx, r.Client, lbuName, timeout)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to set LBU Backend_vms state",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(lbuVmsErrWait, err.Error())
 		return
 	}
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+
+	// We set the last read response to the state
+	stateData, err = r.flatten(ctx, data, *lbu)
+	if err != nil {
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateData)...)
 }
 
 func (r *resourceLbuVms) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	var data LbuBackendVmsModel
+	var data lbuBackendVmsModel
 
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	err := setLbuBackendState(ctx, r, &data)
+
+	timeout, diags := data.Timeouts.Read(ctx, ReadDefaultTimeout)
+	if fwhelpers.CheckDiags(resp, diags) {
+		return
+	}
+
+	stateData, err := r.read(ctx, timeout, data)
 	if err != nil {
 		if errors.Is(err, ErrResourceEmpty) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(
-			"Unable to set LBU Backend_vms API response values.",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateData)...)
 }
 
 func (r *resourceLbuVms) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var dataPlan, dataState LbuBackendVmsModel
+	var dataPlan, dataState lbuBackendVmsModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &dataPlan)...)
 	resp.Diagnostics.Append(req.State.Get(ctx, &dataState)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	updateTimeout, diags := dataPlan.Timeouts.Update(ctx, UpdateDefaultTimeout)
+	timeout, diags := dataPlan.Timeouts.Update(ctx, UpdateDefaultTimeout)
 	if fwhelpers.CheckDiags(resp, diags) {
 		return
 	}
 
 	linkReq, unLinkReq, err := buildUpdateBackendsRequest(ctx, dataState.LoadBalancerName.ValueString(), &dataState, &dataPlan)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to update LBU backends.",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(lbuVmsErrUpdate, err.Error())
 		return
 	}
 	if (unLinkReq.BackendVmIds != nil && len(*unLinkReq.BackendVmIds) > 0) || (unLinkReq.BackendIps != nil && len(*unLinkReq.BackendIps) > 0) {
-		_, err := r.Client.UnlinkLoadBalancerBackendMachines(ctx, unLinkReq, options.WithRetryTimeout(updateTimeout))
+		respUpdate, err := r.Client.UnlinkLoadBalancerBackendMachines(ctx, unLinkReq, options.WithRetryTimeout(timeout))
 		if err != nil {
-			resp.Diagnostics.AddError(
-				"Unable to remove LBU backend vms.",
-				err.Error(),
-			)
+			resp.Diagnostics.AddError(lbuVmsErrRemove, err.Error())
 			return
 		}
+		dataPlan.RequestId = to.String(respUpdate.ResponseContext.RequestId)
 	}
 
 	if (linkReq.BackendVmIds != nil && len(*linkReq.BackendVmIds) > 0) || (linkReq.BackendIps != nil && len(*linkReq.BackendIps) > 0) {
-		_, err := r.Client.LinkLoadBalancerBackendMachines(ctx, linkReq, options.WithRetryTimeout(updateTimeout))
+		respUpdate, err := r.Client.LinkLoadBalancerBackendMachines(ctx, linkReq, options.WithRetryTimeout(timeout))
 		if err != nil {
-			resp.Diagnostics.AddError(
-				"Unable to add LBU backend vms.",
-				err.Error(),
-			)
+			resp.Diagnostics.AddError(lbuVmsErrAdd, err.Error())
 			return
 		}
+		dataPlan.RequestId = to.String(respUpdate.ResponseContext.RequestId)
 	}
-	if err = waitForLbuActive(ctx, r.Client, dataState.LoadBalancerName.ValueString(), updateTimeout); err != nil {
-		resp.Diagnostics.AddError(
-			"Error waiting for load balancer to become active after updating backends",
-			err.Error(),
-		)
+	lbu, err := waitForLbuActive(ctx, r.Client, dataState.LoadBalancerName.ValueString(), timeout)
+	if err != nil {
+		resp.Diagnostics.AddError(lbuVmsErrWait, err.Error())
 		return
 	}
 
-	err = setLbuBackendState(ctx, r, &dataPlan)
+	// We set the last read response to the state
+	stateData, err := r.flatten(ctx, dataPlan, *lbu)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to set LBU backend vms state after updating.",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
-	resp.Diagnostics.Append(resp.State.Set(ctx, &dataPlan)...)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateData)...)
 }
 
 func (r *resourceLbuVms) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	var data LbuBackendVmsModel
+	var data lbuBackendVmsModel
 
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	deleteTimeout, diags := data.Timeouts.Delete(ctx, DeleteDefaultTimeout)
+	timeout, diags := data.Timeouts.Delete(ctx, DeleteDefaultTimeout)
 	if fwhelpers.CheckDiags(resp, diags) {
 		return
 	}
@@ -311,57 +320,56 @@ func (r *resourceLbuVms) Delete(ctx context.Context, req resource.DeleteRequest,
 		unLinkReq.BackendIps = &listVmsIps
 	}
 
-	_, err := r.Client.UnlinkLoadBalancerBackendMachines(ctx, unLinkReq, options.WithRetryTimeout(deleteTimeout))
+	_, err := r.Client.UnlinkLoadBalancerBackendMachines(ctx, unLinkReq, options.WithRetryTimeout(timeout))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to delete LBU backend vms.",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(lbuVmsErrDelete, err.Error())
 	}
 }
 
-func setLbuBackendState(ctx context.Context, r *resourceLbuVms, data *LbuBackendVmsModel) error {
+func (r *resourceLbuVms) read(ctx context.Context, timeout time.Duration, data lbuBackendVmsModel) (lbuBackendVmsModel, error) {
 	lbuFilters := osc.FiltersLoadBalancer{
 		LoadBalancerNames: &[]string{data.LoadBalancerName.ValueString()},
-	}
-
-	readTimeout, diags := data.Timeouts.Read(ctx, ReadDefaultTimeout)
-	if diags.HasError() {
-		return fmt.Errorf("unable to parse read timeout value: %v", diags.Errors())
 	}
 
 	readReq := osc.ReadLoadBalancersRequest{
 		Filters: &lbuFilters,
 	}
-	readResp, err := r.Client.ReadLoadBalancers(ctx, readReq, options.WithRetryTimeout(readTimeout))
+	readResp, err := r.Client.ReadLoadBalancers(ctx, readReq, options.WithRetryTimeout(timeout))
 	if err != nil {
-		return err
+		return data, err
 	}
 	if readResp.LoadBalancers == nil || len(*readResp.LoadBalancers) == 0 {
-		return ErrResourceEmpty
+		return data, ErrResourceEmpty
 	}
 
 	data.RequestId = to.String(*readResp.ResponseContext.RequestId)
 	lbu := (*readResp.LoadBalancers)[0]
+
+	return r.flatten(ctx, data, lbu)
+}
+
+func (r *resourceLbuVms) flatten(ctx context.Context, data lbuBackendVmsModel, lbu osc.LoadBalancer) (lbuBackendVmsModel, error) {
 	if fwhelpers.IsSet(data.BackendVmIds) {
-		data.BackendVmIds, diags = to.Set(ctx, lbu.BackendVmIds)
-		if diags.HasError() {
-			return fmt.Errorf("unable to set lbu backend_vm_ips: %v", diags.Errors())
+		vmIds, diag := to.Set(ctx, lbu.BackendVmIds)
+		if diag.HasError() {
+			return data, from.Diag(diag)
 		}
+		data.BackendVmIds = vmIds
 	}
 	if !data.BackendIps.IsUnknown() && !data.BackendIps.IsNull() {
-		data.BackendIps, diags = to.Set(ctx, lbu.BackendIps)
-		if diags.HasError() {
-			return fmt.Errorf("unable to set lbu backend_ips: %v", diags.Errors())
+		ips, diag := to.Set(ctx, lbu.BackendIps)
+		if diag.HasError() {
+			return data, from.Diag(diag)
 		}
+		data.BackendIps = ips
 	}
 	data.LoadBalancerName = to.String(lbu.LoadBalancerName)
 	data.Id = to.String(lbu.LoadBalancerName)
 
-	return nil
+	return data, nil
 }
 
-func getSlicesLbuBackendVms(ctx context.Context, data *LbuBackendVmsModel) ([]string, []string, diag.Diagnostics) {
+func getSlicesLbuBackendVms(ctx context.Context, data *lbuBackendVmsModel) ([]string, []string, diag.Diagnostics) {
 	listVmsIds := []string{}
 	listVmsIps := []string{}
 	diags := data.BackendVmIds.ElementsAs(ctx, &listVmsIds, false)
@@ -375,7 +383,7 @@ func getSlicesLbuBackendVms(ctx context.Context, data *LbuBackendVmsModel) ([]st
 	return listVmsIds, listVmsIps, diags
 }
 
-func buildUpdateBackendsRequest(ctx context.Context, lbuName string, stateData, planData *LbuBackendVmsModel) (osc.LinkLoadBalancerBackendMachinesRequest, osc.UnlinkLoadBalancerBackendMachinesRequest, error) {
+func buildUpdateBackendsRequest(ctx context.Context, lbuName string, stateData, planData *lbuBackendVmsModel) (osc.LinkLoadBalancerBackendMachinesRequest, osc.UnlinkLoadBalancerBackendMachinesRequest, error) {
 	linkReq := osc.LinkLoadBalancerBackendMachinesRequest{
 		LoadBalancerName: lbuName,
 	}

--- a/internal/services/oapi/resource_main_route_table_link.go
+++ b/internal/services/oapi/resource_main_route_table_link.go
@@ -26,6 +26,11 @@ var (
 	_ resource.ResourceWithModifyPlan = &resourceMainRouteTableLink{}
 )
 
+const (
+	mainRouteTableLinkErrCreate = "Unable to update Main Route Table Link"
+	mainRouteTableLinkErrDelete = "Unable to unlink Main Route Table"
+)
+
 type MainRouteTableLinkModel struct {
 	RouteTableLinkCoreModel
 	DefaultRouteTableId types.String `tfsdk:"default_route_table_id"`
@@ -143,12 +148,12 @@ func (r *resourceMainRouteTableLink) Create(ctx context.Context, req resource.Cr
 		return
 	}
 
-	createTimeout, diags := data.Timeouts.Create(ctx, CreateDefaultTimeout)
+	timeout, diags := data.Timeouts.Create(ctx, CreateDefaultTimeout)
 	if fwhelpers.CheckDiags(resp, diags) {
 		return
 	}
 
-	routeTableResp, err := r.GetAssociatedRouteTable(ctx, createTimeout, data)
+	routeTableResp, err := r.GetAssociatedRouteTable(ctx, timeout, data)
 	if err != nil {
 		return
 	}
@@ -161,27 +166,23 @@ func (r *resourceMainRouteTableLink) Create(ctx context.Context, req resource.Cr
 		LinkRouteTableId: oldLinkRouteTableId,
 	}
 
-	createResp, err := r.Client.UpdateRouteTableLink(ctx, createReq, options.WithRetryTimeout(createTimeout))
+	createResp, err := r.Client.UpdateRouteTableLink(ctx, createReq, options.WithRetryTimeout(timeout))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to set the Main Route Table.",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(mainRouteTableLinkErrCreate, err.Error())
 		return
 	}
-	data.DefaultRouteTableId = to.String(defaultRouteTableId)
-
 	linkRouteTableId := ptr.From(createResp.LinkRouteTableId)
+
+	data.DefaultRouteTableId = to.String(defaultRouteTableId)
 	data.RequestId = to.String(createResp.ResponseContext.RequestId)
 	data.LinkRouteTableId = to.String(linkRouteTableId)
 	data.Id = to.String(linkRouteTableId)
+	// The API response does not contain enough information to set the state directly, which would cause an error.
+	// The next read will fill the state
 
-	data, err = r.read(ctx, createTimeout, data)
+	data, err = r.read(ctx, timeout, data)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to set Main Route Table Link state",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -206,10 +207,7 @@ func (r *resourceMainRouteTableLink) Read(ctx context.Context, req resource.Read
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(
-			"Unable to set Main Route Table Link API response values.",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -226,7 +224,7 @@ func (r *resourceMainRouteTableLink) Delete(ctx context.Context, req resource.De
 		return
 	}
 
-	deleteTimeout, diags := data.Timeouts.Delete(ctx, DeleteDefaultTimeout)
+	timeout, diags := data.Timeouts.Delete(ctx, DeleteDefaultTimeout)
 	if fwhelpers.CheckDiags(resp, diags) {
 		return
 	}
@@ -236,12 +234,9 @@ func (r *resourceMainRouteTableLink) Delete(ctx context.Context, req resource.De
 		RouteTableId:     data.DefaultRouteTableId.ValueString(),
 	}
 
-	_, err := r.Client.UpdateRouteTableLink(ctx, delReq, options.WithRetryTimeout(deleteTimeout))
+	_, err := r.Client.UpdateRouteTableLink(ctx, delReq, options.WithRetryTimeout(timeout))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to unlink the Main Route Table.",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(mainRouteTableLinkErrDelete, err.Error())
 	}
 }
 

--- a/internal/services/oapi/resource_nat_service.go
+++ b/internal/services/oapi/resource_nat_service.go
@@ -31,11 +31,9 @@ var (
 )
 
 const (
-	natSvcErrCreate       = "Unable to create NAT Service"
-	natSvcErrRead         = "Unable to read NAT Service"
-	natSvcErrDelete       = "Unable to delete NAT Service"
-	natSvcErrState        = "Unable to set NAT Service state"
-	natSvcErrNotAvailable = "Unable to wait for NAT Service to be available"
+	natSvcErrCreate = "Unable to create NAT Service"
+	natSvcErrDelete = "Unable to delete NAT Service"
+	natSvcErrState  = "Unable to wait for NAT Service state"
 )
 
 type natServiceModel struct {
@@ -199,17 +197,17 @@ func (r *natServiceResource) Create(ctx context.Context, req resource.CreateRequ
 	createResp := respAny.(*osc.CreateNatServiceResponse)
 
 	natServiceId := createResp.NatService.NatServiceId
+	data.RequestId = to.String(createResp.ResponseContext.RequestId)
 	data.Id = to.String(natServiceId)
 	data.NatServiceId = to.String(natServiceId)
 
-	stateConf := &stateconf.StateChangeConf[osc.NatServiceState]{
-		Pending: stateconf.States(osc.NatServiceStatePending),
-		Target:  stateconf.States(osc.NatServiceStateAvailable),
-		Timeout: timeout,
-		Refresh: r.stateRefreshFunc(natServiceId),
+	stateData, err := r.flatten(ctx, data, *createResp.NatService)
+	if err != nil {
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
+		return
 	}
-	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
-		resp.Diagnostics.AddError(natSvcErrNotAvailable, err.Error())
+	diags = resp.State.Set(ctx, &stateData)
+	if fwhelpers.CheckDiags(resp, diags) {
 		return
 	}
 
@@ -218,9 +216,22 @@ func (r *natServiceResource) Create(ctx context.Context, req resource.CreateRequ
 		return
 	}
 
-	stateData, err := r.read(ctx, timeout, data)
+	stateConf := &stateconf.StateChangeConf[osc.NatServiceState]{
+		Pending: stateconf.States(osc.NatServiceStatePending),
+		Target:  stateconf.States(osc.NatServiceStateAvailable),
+		Timeout: timeout,
+		Refresh: r.stateRefreshFunc(natServiceId),
+	}
+	natAny, err := stateConf.WaitForStateContext(ctx)
 	if err != nil {
 		resp.Diagnostics.AddError(natSvcErrState, err.Error())
+		return
+	}
+
+	// We set the last read response to the state
+	stateData, err = r.flatten(ctx, data, natAny.(osc.NatService))
+	if err != nil {
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
@@ -242,7 +253,7 @@ func (r *natServiceResource) Read(ctx context.Context, req resource.ReadRequest,
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(natSvcErrRead, err.Error())
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
@@ -273,7 +284,7 @@ func (r *natServiceResource) Update(ctx context.Context, req resource.UpdateRequ
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(natSvcErrState, err.Error())
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
@@ -332,6 +343,12 @@ func (r *natServiceResource) read(ctx context.Context, timeout time.Duration, da
 		return data, ErrResourceEmpty
 	}
 
+	data.RequestId = to.String(resp.ResponseContext.RequestId)
+
+	return r.flatten(ctx, data, natService)
+}
+
+func (r *natServiceResource) flatten(ctx context.Context, data natServiceModel, natService osc.NatService) (natServiceModel, error) {
 	tags, diag := flattenOAPITagsFW(ctx, natService.Tags)
 	if diag.HasError() {
 		return data, from.Diag(diag)
@@ -343,7 +360,6 @@ func (r *natServiceResource) read(ctx context.Context, timeout time.Duration, da
 	}
 
 	data.Tags = tags
-	data.RequestId = to.String(resp.ResponseContext.RequestId)
 	data.Id = to.String(natService.NatServiceId)
 	data.NatServiceId = to.String(natService.NatServiceId)
 	data.NetId = to.String(natService.NetId)
@@ -386,6 +402,7 @@ func (r *natServiceResource) stateRefreshFunc(id string) func(context.Context) (
 		}
 
 		natService := (*resp.NatServices)[0]
-		return resp, natService.State, nil
+
+		return natService, natService.State, nil
 	}
 }

--- a/internal/services/oapi/resource_nat_service_test.go
+++ b/internal/services/oapi/resource_nat_service_test.go
@@ -1,6 +1,7 @@
 package oapi_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -28,6 +29,26 @@ func TestAccNet_WithNatService_Migration(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		Steps: testacc.FrameworkMigrationTestSteps("1.5.0",
 			testAccOAPINatGatewayConfig,
+		),
+	})
+}
+
+func TestAccNet_WithNatService_CreateFailureKeepsState(t *testing.T) {
+	resourceName := "outscale_nat_service.nat_service"
+	invalidTagKey := strings.Repeat("a", 256)
+	tagValue := "testacc-resource-nat-service"
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testacc.ProtoV6ProviderFactories(),
+		Steps: testacc.CreateFailureReplacementSteps(
+			resourceName,
+			testAccOAPINatGatewayConfigWithTag(invalidTagKey, tagValue),
+			testAccOAPINatGatewayConfigWithTag("Name", tagValue),
+			resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttrSet(resourceName, "nat_service_id"),
+				resource.TestCheckResourceAttr(resourceName, "tags.0.value", tagValue),
+				resource.TestCheckResourceAttr(resourceName, "state", "available"),
+			),
 		),
 	})
 }
@@ -78,3 +99,57 @@ const testAccOAPINatGatewayConfig = `
 		internet_service_id = outscale_internet_service.outscale_internet_service.id
 	}
 `
+
+func testAccOAPINatGatewayConfigWithTag(tagKey, tagValue string) string {
+	return `
+	resource "outscale_net" "outscale_net" {
+		ip_range = "10.0.0.0/16"
+
+		tags {
+			key = "Name"
+			value = "testacc-nat-service-rs"
+		}
+	}
+
+	resource "outscale_subnet" "outscale_subnet" {
+		net_id   = outscale_net.outscale_net.net_id
+		ip_range = "10.0.0.0/18"
+	}
+
+	resource "outscale_public_ip" "outscale_public_ip" {}
+
+	resource "outscale_nat_service" "nat_service" {
+		depends_on   = [outscale_route.outscale_route]
+		subnet_id    = outscale_subnet.outscale_subnet.subnet_id
+		public_ip_id = outscale_public_ip.outscale_public_ip.public_ip_id
+
+		tags {
+			key = "` + tagKey + `"
+			value = "` + tagValue + `"
+		}
+	}
+
+	resource "outscale_route_table" "outscale_route_table" {
+		net_id = outscale_net.outscale_net.net_id
+	}
+
+	resource "outscale_route" "outscale_route" {
+		depends_on   = [outscale_route_table_link.outscale_route_table_link]
+		destination_ip_range = "0.0.0.0/0"
+		gateway_id           = outscale_internet_service_link.outscale_internet_service_link.internet_service_id
+		route_table_id       = outscale_route_table.outscale_route_table.route_table_id
+	}
+
+	resource "outscale_route_table_link" "outscale_route_table_link" {
+		subnet_id      = outscale_subnet.outscale_subnet.subnet_id
+		route_table_id = outscale_route_table.outscale_route_table.id
+	}
+
+	resource "outscale_internet_service" "outscale_internet_service" {}
+
+	resource "outscale_internet_service_link" "outscale_internet_service_link" {
+		net_id              = outscale_net.outscale_net.net_id
+		internet_service_id = outscale_internet_service.outscale_internet_service.id
+	}
+`
+}

--- a/internal/services/oapi/resource_net.go
+++ b/internal/services/oapi/resource_net.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -21,6 +22,7 @@ import (
 	"github.com/outscale/osc-sdk-go/v3/pkg/osc"
 	"github.com/outscale/terraform-provider-outscale/internal/client"
 	"github.com/outscale/terraform-provider-outscale/internal/framework/fwhelpers"
+	"github.com/outscale/terraform-provider-outscale/internal/framework/fwhelpers/from"
 	"github.com/outscale/terraform-provider-outscale/internal/framework/fwhelpers/to"
 	"github.com/outscale/terraform-provider-outscale/internal/framework/modifyplans"
 )
@@ -28,6 +30,12 @@ import (
 var (
 	_ resource.Resource              = &resourceNet{}
 	_ resource.ResourceWithConfigure = &resourceNet{}
+)
+
+const (
+	netErrCreate  = "Unable to create Net"
+	netErrDelete  = "Unable to delete Net"
+	netErrIPRange = "Unable to validate Net ip_range"
 )
 
 type NetModel struct {
@@ -157,21 +165,18 @@ func (r *resourceNet) Create(ctx context.Context, req resource.CreateRequest, re
 
 	_, valideIpRange, err := net.ParseCIDR(data.IpRange.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to parse ip_range value: "+data.IpRange.ValueString(),
-			"Error: "+err.Error(),
-		)
+		resp.Diagnostics.AddError(netErrIPRange, err.Error())
 		return
 	}
 	if data.IpRange.ValueString() != valideIpRange.String() {
 		resp.Diagnostics.AddError(
-			"Invalide net ip_range value: "+data.IpRange.ValueString(),
+			"Invalid net ip_range value: "+data.IpRange.ValueString(),
 			"Error: ip_range value should be: "+valideIpRange.String(),
 		)
 		return
 	}
 
-	createTimeout, diags := data.Timeouts.Create(ctx, CreateDefaultTimeout)
+	timeout, diags := data.Timeouts.Create(ctx, CreateDefaultTimeout)
 	if fwhelpers.CheckDiags(resp, diags) {
 		return
 	}
@@ -184,29 +189,35 @@ func (r *resourceNet) Create(ctx context.Context, req resource.CreateRequest, re
 		createReq.Tenancy = data.Tenancy.ValueStringPointer()
 	}
 
-	createResp, err := r.Client.CreateNet(ctx, createReq, options.WithRetryTimeout(createTimeout))
+	createResp, err := r.Client.CreateNet(ctx, createReq, options.WithRetryTimeout(timeout))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to Create Resource Net",
-			"Error: "+err.Error(),
-		)
+		resp.Diagnostics.AddError(netErrCreate, err.Error())
 		return
 	}
 
 	data.RequestId = to.String(createResp.ResponseContext.RequestId)
 	net := ptr.From(createResp.Net)
+	data.NetId = to.String(net.NetId)
+	data.Id = to.String(net.NetId)
 
-	diag := createOAPITagsFW(ctx, r.Client, createTimeout, data.Tags, net.NetId)
+	stateData, err := r.flatten(ctx, data, net)
+	if err != nil {
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
+		return
+	}
+	diags = resp.State.Set(ctx, &stateData)
+	if fwhelpers.CheckDiags(resp, diags) {
+		return
+	}
+
+	diag := createOAPITagsFW(ctx, r.Client, timeout, data.Tags, net.NetId)
 	if fwhelpers.CheckDiags(resp, diag) {
 		return
 	}
-	data.NetId = to.String(net.NetId)
-	data, err = setNetState(ctx, r, data)
+
+	data, err = r.read(ctx, timeout, data)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to set net state",
-			"Error: "+err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -221,16 +232,18 @@ func (r *resourceNet) Read(ctx context.Context, req resource.ReadRequest, resp *
 		return
 	}
 
-	data, err = setNetState(ctx, r, data)
+	timeout, diags := data.Timeouts.Read(ctx, ReadDefaultTimeout)
+	if fwhelpers.CheckDiags(resp, diags) {
+		return
+	}
+
+	data, err = r.read(ctx, timeout, data)
 	if err != nil {
 		if errors.Is(err, ErrResourceEmpty) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(
-			"Unable to set net state",
-			"Error: "+err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -255,12 +268,9 @@ func (r *resourceNet) Update(ctx context.Context, req resource.UpdateRequest, re
 	}
 
 	stateData.Timeouts = planData.Timeouts
-	data, err := setNetState(ctx, r, stateData)
+	data, err := r.read(ctx, timeout, stateData)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to set net state",
-			"Error: "+err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -274,7 +284,7 @@ func (r *resourceNet) Delete(ctx context.Context, req resource.DeleteRequest, re
 		return
 	}
 
-	deleteTimeout, diags := data.Timeouts.Delete(ctx, DeleteDefaultTimeout)
+	timeout, diags := data.Timeouts.Delete(ctx, DeleteDefaultTimeout)
 	if fwhelpers.CheckDiags(resp, diags) {
 		return
 	}
@@ -282,21 +292,14 @@ func (r *resourceNet) Delete(ctx context.Context, req resource.DeleteRequest, re
 	delReq := osc.DeleteNetRequest{
 		NetId: data.NetId.ValueString(),
 	}
-	_, err := r.Client.DeleteNet(ctx, delReq, options.WithRetryTimeout(deleteTimeout))
+	_, err := r.Client.DeleteNet(ctx, delReq, options.WithRetryTimeout(timeout))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to Delete net",
-			"Error: "+err.Error(),
-		)
+		resp.Diagnostics.AddError(netErrDelete, err.Error())
 	}
 }
 
-func setNetState(ctx context.Context, r *resourceNet, data NetModel) (NetModel, error) {
-	readTimeout, diags := data.Timeouts.Read(ctx, ReadDefaultTimeout)
-	if diags.HasError() {
-		return data, fmt.Errorf("unable to parse 'net' read timeout value: %v", diags.Errors())
-	}
-	ctxWithTimeout, cancel := context.WithTimeout(ctx, readTimeout)
+func (r *resourceNet) read(ctx context.Context, timeout time.Duration, data NetModel) (NetModel, error) {
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	net, err := r.Batcher.Read(ctxWithTimeout, data.NetId.ValueString())
@@ -307,9 +310,13 @@ func setNetState(ctx context.Context, r *resourceNet, data NetModel) (NetModel, 
 		return data, err
 	}
 
+	return r.flatten(ctx, data, *net)
+}
+
+func (r *resourceNet) flatten(ctx context.Context, data NetModel, net osc.Net) (NetModel, error) {
 	tags, diag := flattenOAPITagsFW(ctx, net.Tags)
 	if diag.HasError() {
-		return data, fmt.Errorf("unable to flatten tags: %v", diags.Errors())
+		return data, from.Diag(diag)
 	}
 	data.Tags = tags
 

--- a/internal/services/oapi/resource_net_access_point.go
+++ b/internal/services/oapi/resource_net_access_point.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 
@@ -17,6 +18,7 @@ import (
 	"github.com/outscale/osc-sdk-go/v3/pkg/osc"
 	"github.com/outscale/terraform-provider-outscale/internal/client"
 	"github.com/outscale/terraform-provider-outscale/internal/framework/fwhelpers"
+	"github.com/outscale/terraform-provider-outscale/internal/framework/fwhelpers/from"
 	"github.com/outscale/terraform-provider-outscale/internal/framework/fwhelpers/to"
 	"github.com/outscale/terraform-provider-outscale/internal/framework/stateconf"
 	"github.com/samber/lo"
@@ -27,6 +29,13 @@ var (
 	_ resource.ResourceWithConfigure   = &resourceNetAccessPoint{}
 	_ resource.ResourceWithImportState = &resourceNetAccessPoint{}
 	_ resource.ResourceWithModifyPlan  = &resourceNetAccessPoint{}
+)
+
+const (
+	netAccessPointErrCreate = "Unable to create Net Access Point"
+	netAccessPointErrUpdate = "Unable to update Net Access Point"
+	netAccessPointErrDelete = "Unable to delete Net Access Point"
+	netAccessPointErrWait   = "Unable to wait for Net Access Point state"
 )
 
 type NetAccessPointModel struct {
@@ -160,7 +169,7 @@ func (r *resourceNetAccessPoint) Create(ctx context.Context, req resource.Create
 		return
 	}
 
-	createTimeout, diags := data.Timeouts.Create(ctx, CreateDefaultTimeout)
+	timeout, diags := data.Timeouts.Create(ctx, CreateDefaultTimeout)
 	if fwhelpers.CheckDiags(resp, diags) {
 		return
 	}
@@ -180,18 +189,28 @@ func (r *resourceNetAccessPoint) Create(ctx context.Context, req resource.Create
 		createReq.RouteTableIds = &rtIds
 	}
 
-	createResp, err := r.Client.CreateNetAccessPoint(ctx, createReq, options.WithRetryTimeout(createTimeout))
+	createResp, err := r.Client.CreateNetAccessPoint(ctx, createReq, options.WithRetryTimeout(timeout))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to create Net Access Point resource.",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(netAccessPointErrCreate, err.Error())
 		return
 	}
-	data.RequestId = to.String(createResp.ResponseContext.RequestId)
-	netAccessPoint := createResp.NetAccessPoint
 
-	diag := createOAPITagsFW(ctx, r.Client, createTimeout, data.Tags, netAccessPoint.NetAccessPointId)
+	netAccessPoint := *createResp.NetAccessPoint
+	data.RequestId = to.String(createResp.ResponseContext.RequestId)
+	data.NetAccessPointId = to.String(netAccessPoint.NetAccessPointId)
+	data.Id = to.String(netAccessPoint.NetAccessPointId)
+
+	stateData, err := r.flatten(ctx, data, netAccessPoint)
+	if err != nil {
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
+		return
+	}
+	diags = resp.State.Set(ctx, &stateData)
+	if fwhelpers.CheckDiags(resp, diags) {
+		return
+	}
+
+	diag := createOAPITagsFW(ctx, r.Client, timeout, data.Tags, netAccessPoint.NetAccessPointId)
 	if fwhelpers.CheckDiags(resp, diag) {
 		return
 	}
@@ -199,31 +218,24 @@ func (r *resourceNetAccessPoint) Create(ctx context.Context, req resource.Create
 	stateConf := &stateconf.StateChangeConf[osc.NetAccessPointState]{
 		Pending: stateconf.States(osc.NetAccessPointStatePending),
 		Target:  stateconf.States(osc.NetAccessPointStateAvailable),
-		Timeout: createTimeout,
-		Refresh: r.stateRefreshFunc(netAccessPoint.NetAccessPointId),
+		Timeout: timeout,
+		Refresh: r.refreshFunc(netAccessPoint.NetAccessPointId),
 	}
 
-	if _, err = stateConf.WaitForStateContext(ctx); err != nil {
-		resp.Diagnostics.AddError(
-			fmt.Sprintf(
-				"Error waiting for Net Access Point (%s) to become available.",
-				netAccessPoint.NetAccessPointId),
-			err.Error(),
-		)
-		return
-	}
-
-	data.NetAccessPointId = to.String(netAccessPoint.NetAccessPointId)
-	data.Id = to.String(netAccessPoint.NetAccessPointId)
-	data, err = setNetAccessPointState(ctx, r, data)
+	napAny, err := stateConf.WaitForStateContext(ctx)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to set Net Access Point state",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(netAccessPointErrWait, err.Error())
 		return
 	}
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+
+	// We set the last read response to the state
+	stateData, err = r.flatten(ctx, data, napAny.(osc.NetAccessPoint))
+	if err != nil {
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateData)...)
 }
 
 func (r *resourceNetAccessPoint) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -234,16 +246,18 @@ func (r *resourceNetAccessPoint) Read(ctx context.Context, req resource.ReadRequ
 		return
 	}
 
-	data, err := setNetAccessPointState(ctx, r, data)
+	timeout, diags := data.Timeouts.Read(ctx, ReadDefaultTimeout)
+	if fwhelpers.CheckDiags(resp, diags) {
+		return
+	}
+
+	data, err := r.read(ctx, timeout, data)
 	if err != nil {
 		if errors.Is(err, ErrResourceEmpty) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(
-			"Unable to set Net Access Point API response values.",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -260,12 +274,12 @@ func (r *resourceNetAccessPoint) Update(ctx context.Context, req resource.Update
 		return
 	}
 
-	updateTimeout, diags := planData.Timeouts.Update(ctx, UpdateDefaultTimeout)
+	timeout, diags := planData.Timeouts.Update(ctx, UpdateDefaultTimeout)
 	if fwhelpers.CheckDiags(resp, diags) {
 		return
 	}
 
-	diags = updateOAPITagsFW(ctx, r.Client, updateTimeout, stateData.Tags, planData.Tags, stateData.NetAccessPointId.ValueString())
+	diags = updateOAPITagsFW(ctx, r.Client, timeout, stateData.Tags, planData.Tags, stateData.NetAccessPointId.ValueString())
 	if fwhelpers.CheckDiags(resp, diags) {
 		return
 	}
@@ -290,25 +304,20 @@ func (r *resourceNetAccessPoint) Update(ctx context.Context, req resource.Update
 		if len(removeIds) > 0 {
 			updateReq.RemoveRouteTableIds = &removeIds
 		}
-		_, err := r.Client.UpdateNetAccessPoint(ctx, updateReq, options.WithRetryTimeout(updateTimeout))
+		_, err := r.Client.UpdateNetAccessPoint(ctx, updateReq, options.WithRetryTimeout(timeout))
 		if err != nil {
-			resp.Diagnostics.AddError(
-				"Unable to update Net Access Point resource.",
-				err.Error(),
-			)
+			resp.Diagnostics.AddError(netAccessPointErrUpdate, err.Error())
 			return
 		}
 	}
 
 	stateData.Timeouts = planData.Timeouts
-	data, err := setNetAccessPointState(ctx, r, stateData)
+	data, err := r.read(ctx, timeout, stateData)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to set Net Access Point state.",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, data)...)
 }
 
@@ -320,7 +329,7 @@ func (r *resourceNetAccessPoint) Delete(ctx context.Context, req resource.Delete
 		return
 	}
 
-	deleteTimeout, diags := data.Timeouts.Delete(ctx, DeleteDefaultTimeout)
+	timeout, diags := data.Timeouts.Delete(ctx, DeleteDefaultTimeout)
 	if fwhelpers.CheckDiags(resp, diags) {
 		return
 	}
@@ -329,28 +338,20 @@ func (r *resourceNetAccessPoint) Delete(ctx context.Context, req resource.Delete
 		NetAccessPointId: data.NetAccessPointId.ValueString(),
 	}
 
-	_, err := r.Client.DeleteNetAccessPoint(ctx, delReq, options.WithRetryTimeout(deleteTimeout))
+	_, err := r.Client.DeleteNetAccessPoint(ctx, delReq, options.WithRetryTimeout(timeout))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to Delete Net Access Point.",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(netAccessPointErrDelete, err.Error())
 	}
 }
 
-func setNetAccessPointState(ctx context.Context, r *resourceNetAccessPoint, data NetAccessPointModel) (NetAccessPointModel, error) {
+func (r *resourceNetAccessPoint) read(ctx context.Context, timeout time.Duration, data NetAccessPointModel) (NetAccessPointModel, error) {
 	readReq := osc.ReadNetAccessPointsRequest{
 		Filters: &osc.FiltersNetAccessPoint{
 			NetAccessPointIds: &[]string{data.NetAccessPointId.ValueString()},
 		},
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, ReadDefaultTimeout)
-	if diags.HasError() {
-		return data, fmt.Errorf("unable to parse 'net access point' read timeout value: %v", diags.Errors())
-	}
-
-	readResp, err := r.Client.ReadNetAccessPoints(ctx, readReq, options.WithRetryTimeout(readTimeout))
+	readResp, err := r.Client.ReadNetAccessPoints(ctx, readReq, options.WithRetryTimeout(timeout))
 	if err != nil {
 		return data, err
 	}
@@ -361,13 +362,17 @@ func setNetAccessPointState(ctx context.Context, r *resourceNetAccessPoint, data
 	}
 	netAccessPoint := (*readResp.NetAccessPoints)[0]
 
+	return r.flatten(ctx, data, netAccessPoint)
+}
+
+func (r *resourceNetAccessPoint) flatten(ctx context.Context, data NetAccessPointModel, netAccessPoint osc.NetAccessPoint) (NetAccessPointModel, error) {
 	routeTablesIds, diags := types.SetValueFrom(ctx, types.StringType, netAccessPoint.RouteTableIds)
 	if diags.HasError() {
-		return data, fmt.Errorf("unable to convert route tables ids into a set: %v", diags.Errors())
+		return data, from.Diag(diags)
 	}
 	tags, diag := flattenOAPITagsFW(ctx, netAccessPoint.Tags)
 	if diag.HasError() {
-		return data, fmt.Errorf("unable to flatten tags: %v", diags.Errors())
+		return data, from.Diag(diag)
 	}
 	data.Tags = tags
 
@@ -381,7 +386,7 @@ func setNetAccessPointState(ctx context.Context, r *resourceNetAccessPoint, data
 	return data, nil
 }
 
-func (r *resourceNetAccessPoint) stateRefreshFunc(id string) func(ctx context.Context) (any, osc.NetAccessPointState, error) {
+func (r *resourceNetAccessPoint) refreshFunc(id string) func(ctx context.Context) (any, osc.NetAccessPointState, error) {
 	return func(ctx context.Context) (any, osc.NetAccessPointState, error) {
 		readReq := osc.ReadNetAccessPointsRequest{Filters: &osc.FiltersNetAccessPoint{NetAccessPointIds: &[]string{id}}}
 
@@ -394,6 +399,6 @@ func (r *resourceNetAccessPoint) stateRefreshFunc(id string) func(ctx context.Co
 		}
 
 		nap := (*resp.NetAccessPoints)[0]
-		return resp, nap.State, nil
+		return nap, nap.State, nil
 	}
 }

--- a/internal/services/oapi/resource_net_access_point_test.go
+++ b/internal/services/oapi/resource_net_access_point_test.go
@@ -2,6 +2,7 @@ package oapi_test
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -50,7 +51,31 @@ func TestAccNet_AccessPoint_Migration(t *testing.T) {
 	})
 }
 
+func TestAccNet_AccessPoint_CreateFailureKeepsState(t *testing.T) {
+	serviceName := fmt.Sprintf("com.outscale.%s.api", utils.GetRegion())
+	resourceName := "outscale_net_access_point.net_access_point_1"
+	invalidTagKey := strings.Repeat("a", 256)
+	tagValue := "testacc-nap"
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testacc.ProtoV6ProviderFactories(),
+		Steps: testacc.CreateFailureReplacementSteps(
+			resourceName,
+			testAccOutscaleNetAccessPointConfigWithTag(serviceName, invalidTagKey, tagValue),
+			testAccOutscaleNetAccessPointConfigWithTag(serviceName, "name", tagValue),
+			resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttrSet(resourceName, "net_access_point_id"),
+				resource.TestCheckResourceAttr(resourceName, "tags.0.value", tagValue),
+			),
+		),
+	})
+}
+
 func testAccOutscaleNetAccessPointConfig(sName string) string {
+	return testAccOutscaleNetAccessPointConfigWithTag(sName, "name", "terraform-Net-Access-Point")
+}
+
+func testAccOutscaleNetAccessPointConfigWithTag(sName, tagKey, tagValue string) string {
 	return fmt.Sprintf(`
                 resource "outscale_net" "outscale_net" {
                         ip_range = "10.0.0.0/16"
@@ -65,10 +90,10 @@ func testAccOutscaleNetAccessPointConfig(sName string) string {
                         route_table_ids = [outscale_route_table.route_table-1.route_table_id]
                         service_name    = "%s"
                         tags {
-                              key       = "name"
-                              value     = "terraform-Net-Access-Point"
+				      key       = %q
+				      value     = %q
                         }
 
                 }
-	`, sName)
+	`, sName, tagKey, tagValue)
 }

--- a/internal/services/oapi/resource_net_attributes.go
+++ b/internal/services/oapi/resource_net_attributes.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -16,6 +17,7 @@ import (
 	"github.com/outscale/osc-sdk-go/v3/pkg/osc"
 	"github.com/outscale/terraform-provider-outscale/internal/client"
 	"github.com/outscale/terraform-provider-outscale/internal/framework/fwhelpers"
+	"github.com/outscale/terraform-provider-outscale/internal/framework/fwhelpers/from"
 	"github.com/outscale/terraform-provider-outscale/internal/framework/fwhelpers/to"
 )
 
@@ -24,6 +26,11 @@ var (
 	_ resource.ResourceWithConfigure   = &resourceNetAttributes{}
 	_ resource.ResourceWithImportState = &resourceNetAttributes{}
 	_ resource.ResourceWithModifyPlan  = &resourceNetAttributes{}
+)
+
+const (
+	netAttributesErrCreate = "Unable to create Net Attributes"
+	netAttributesErrUpdate = "Unable to update Net Attributes"
 )
 
 type NetAttributesModel struct {
@@ -148,7 +155,7 @@ func (r *resourceNetAttributes) Create(ctx context.Context, req resource.CreateR
 		return
 	}
 
-	createTimeout, diags := data.Timeouts.Create(ctx, CreateDefaultTimeout)
+	timeout, diags := data.Timeouts.Create(ctx, CreateDefaultTimeout)
 	if fwhelpers.CheckDiags(resp, diags) {
 		return
 	}
@@ -158,12 +165,9 @@ func (r *resourceNetAttributes) Create(ctx context.Context, req resource.CreateR
 		DhcpOptionsSetId: data.DhcpOptionsSetId.ValueString(),
 	}
 
-	createResp, err := r.Client.UpdateNet(ctx, createReq, options.WithRetryTimeout(createTimeout))
+	createResp, err := r.Client.UpdateNet(ctx, createReq, options.WithRetryTimeout(timeout))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to create Net Attributes.",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(netAttributesErrCreate, err.Error())
 		return
 	}
 	data.RequestId = to.String(createResp.ResponseContext.RequestId)
@@ -171,15 +175,13 @@ func (r *resourceNetAttributes) Create(ctx context.Context, req resource.CreateR
 	data.NetId = to.String(net.NetId)
 	data.Id = to.String(net.NetId)
 
-	data, err = r.read(ctx, data)
+	stateData, err := r.flatten(ctx, data, net)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to set Net Attributes state.",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateData)...)
 }
 
 func (r *resourceNetAttributes) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -190,18 +192,21 @@ func (r *resourceNetAttributes) Read(ctx context.Context, req resource.ReadReque
 		return
 	}
 
-	data, err := r.read(ctx, data)
+	timeout, diags := data.Timeouts.Read(ctx, ReadDefaultTimeout)
+	if fwhelpers.CheckDiags(resp, diags) {
+		return
+	}
+
+	data, err := r.read(ctx, timeout, data)
 	if err != nil {
 		if errors.Is(err, ErrResourceEmpty) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(
-			"Unable to set Net Attributes API response values.",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -225,25 +230,21 @@ func (r *resourceNetAttributes) Update(ctx context.Context, req resource.UpdateR
 
 	createResp, err := r.Client.UpdateNet(ctx, createReq, options.WithRetryTimeout(timeout))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to update Net Attributes.",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(netAttributesErrUpdate, err.Error())
 		return
 	}
-	data.RequestId = to.String(createResp.ResponseContext.RequestId)
+
 	net := ptr.From(createResp.Net)
+	data.RequestId = to.String(createResp.ResponseContext.RequestId)
 	data.NetId = to.String(net.NetId)
 	data.Id = to.String(net.NetId)
 
-	data, err = r.read(ctx, data)
+	data, err = r.read(ctx, timeout, data)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to set Net Attributes state.",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -251,12 +252,8 @@ func (r *resourceNetAttributes) Delete(ctx context.Context, req resource.DeleteR
 	resp.State.RemoveResource(ctx)
 }
 
-func (r *resourceNetAttributes) read(ctx context.Context, data NetAttributesModel) (NetAttributesModel, error) {
-	readTimeout, diags := data.Timeouts.Read(ctx, ReadDefaultTimeout)
-	if diags.HasError() {
-		return data, fmt.Errorf("unable to parse 'net' read timeout value: %v", diags.Errors())
-	}
-	ctxWithTimeout, cancel := context.WithTimeout(ctx, readTimeout)
+func (r *resourceNetAttributes) read(ctx context.Context, timeout time.Duration, data NetAttributesModel) (NetAttributesModel, error) {
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	net, err := r.Batcher.Read(ctxWithTimeout, data.NetId.ValueString())
@@ -267,9 +264,13 @@ func (r *resourceNetAttributes) read(ctx context.Context, data NetAttributesMode
 		return data, err
 	}
 
+	return r.flatten(ctx, data, *net)
+}
+
+func (r *resourceNetAttributes) flatten(ctx context.Context, data NetAttributesModel, net osc.Net) (NetAttributesModel, error) {
 	tags, diag := flattenOAPIComputedTagsFW(ctx, net.Tags)
 	if diag.HasError() {
-		return data, fmt.Errorf("unable to flatten tags: %v", diags.Errors())
+		return data, from.Diag(diag)
 	}
 	data.Tags = tags
 	data.Id = to.String(net.NetId)

--- a/internal/services/oapi/resource_net_peering.go
+++ b/internal/services/oapi/resource_net_peering.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -28,6 +29,13 @@ var (
 	_ resource.ResourceWithConfigure   = &resourceNetPeering{}
 	_ resource.ResourceWithImportState = &resourceNetPeering{}
 	_ resource.ResourceWithModifyPlan  = &resourceNetPeering{}
+)
+
+const (
+	netPeeringErrCreate  = "Unable to create Net Peering"
+	netPeeringErrDelete  = "Unable to delete Net Peering"
+	netPeeringErrWait    = "Unable to wait for Net Peering state"
+	netPeeringErrNetRead = "Unable to read associated Nets of Net Peering"
 )
 
 type NetPeeringModel struct {
@@ -244,7 +252,7 @@ func (r *resourceNetPeering) Create(ctx context.Context, req resource.CreateRequ
 		return
 	}
 
-	createTimeout, diags := data.Timeouts.Create(ctx, CreateDefaultTimeout)
+	timeout, diags := data.Timeouts.Create(ctx, CreateDefaultTimeout)
 	if fwhelpers.CheckDiags(resp, diags) {
 		return
 	}
@@ -265,12 +273,9 @@ func (r *resourceNetPeering) Create(ctx context.Context, req resource.CreateRequ
 			Filters: &filters,
 		}
 
-		readResp, err := r.Client.ReadNets(ctx, req, options.WithRetryTimeout(createTimeout))
+		readResp, err := r.Client.ReadNets(ctx, req, options.WithRetryTimeout(timeout))
 		if err != nil {
-			resp.Diagnostics.AddError(
-				"Unable to read associated nets resource.",
-				err.Error(),
-			)
+			resp.Diagnostics.AddError(netPeeringErrNetRead, err.Error())
 			return
 		}
 		if readResp.Nets != nil && len(*readResp.Nets) != 2 {
@@ -282,18 +287,27 @@ func (r *resourceNetPeering) Create(ctx context.Context, req resource.CreateRequ
 		}
 	}
 
-	createResp, err := r.Client.CreateNetPeering(ctx, createReq, options.WithRetryTimeout(createTimeout))
+	createResp, err := r.Client.CreateNetPeering(ctx, createReq, options.WithRetryTimeout(timeout))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to create net peering resource.",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(netPeeringErrCreate, err.Error())
 		return
 	}
 	data.RequestId = to.String(createResp.ResponseContext.RequestId)
 	netPeering := ptr.From(createResp.NetPeering)
+	data.NetPeeringId = to.String(netPeering.NetPeeringId)
+	data.Id = to.String(netPeering.NetPeeringId)
 
-	diag := createOAPITagsFW(ctx, r.Client, createTimeout, data.Tags, netPeering.NetPeeringId)
+	stateData, err := r.flatten(ctx, data, netPeering)
+	if err != nil {
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
+		return
+	}
+	diags = resp.State.Set(ctx, &stateData)
+	if fwhelpers.CheckDiags(resp, diags) {
+		return
+	}
+
+	diag := createOAPITagsFW(ctx, r.Client, timeout, data.Tags, netPeering.NetPeeringId)
 	if fwhelpers.CheckDiags(resp, diag) {
 		return
 	}
@@ -301,31 +315,24 @@ func (r *resourceNetPeering) Create(ctx context.Context, req resource.CreateRequ
 	stateConf := &stateconf.StateChangeConf[osc.NetPeeringStateName]{
 		Pending: stateconf.States[osc.NetPeeringStateName](),
 		Target:  stateconf.States(osc.NetPeeringStateNamePendingAcceptance, osc.NetPeeringStateNameActive),
-		Timeout: createTimeout,
-		Refresh: r.stateRefreshFunc(netPeering.NetPeeringId),
+		Timeout: timeout,
+		Refresh: r.refreshFunc(netPeering.NetPeeringId),
 	}
 
-	if _, err = stateConf.WaitForStateContext(ctx); err != nil {
-		resp.Diagnostics.AddError(
-			fmt.Sprintf(
-				"Error waiting for Net Peering (%s) to become available.",
-				netPeering.NetPeeringId),
-			err.Error(),
-		)
-		return
-	}
-
-	data.NetPeeringId = to.String(netPeering.NetPeeringId)
-	data.Id = to.String(netPeering.NetPeeringId)
-	data, err = r.read(ctx, data)
+	netPeeringAny, err := stateConf.WaitForStateContext(ctx)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to set Net Peering state",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(netPeeringErrWait, err.Error())
 		return
 	}
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+
+	// We set the last read response to the state
+	stateData, err = r.flatten(ctx, data, netPeeringAny.(osc.NetPeering))
+	if err != nil {
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateData)...)
 }
 
 func (r *resourceNetPeering) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -336,16 +343,18 @@ func (r *resourceNetPeering) Read(ctx context.Context, req resource.ReadRequest,
 		return
 	}
 
-	data, err := r.read(ctx, data)
+	timeout, diags := data.Timeouts.Read(ctx, ReadDefaultTimeout)
+	if fwhelpers.CheckDiags(resp, diags) {
+		return
+	}
+
+	data, err := r.read(ctx, timeout, data)
 	if err != nil {
 		if errors.Is(err, ErrResourceEmpty) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(
-			"Unable to set subnet API response values.",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -370,12 +379,9 @@ func (r *resourceNetPeering) Update(ctx context.Context, req resource.UpdateRequ
 	}
 
 	stateData.Timeouts = planData.Timeouts
-	data, err := r.read(ctx, stateData)
+	data, err := r.read(ctx, timeout, stateData)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to set Net Peering state.",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
@@ -390,7 +396,7 @@ func (r *resourceNetPeering) Delete(ctx context.Context, req resource.DeleteRequ
 		return
 	}
 
-	deleteTimeout, diags := data.Timeouts.Delete(ctx, DeleteDefaultTimeout)
+	timeout, diags := data.Timeouts.Delete(ctx, DeleteDefaultTimeout)
 	if fwhelpers.CheckDiags(resp, diags) {
 		return
 	}
@@ -399,16 +405,13 @@ func (r *resourceNetPeering) Delete(ctx context.Context, req resource.DeleteRequ
 		NetPeeringId: data.NetPeeringId.ValueString(),
 	}
 
-	_, err := r.Client.DeleteNetPeering(ctx, delReq, options.WithRetryTimeout(deleteTimeout))
+	_, err := r.Client.DeleteNetPeering(ctx, delReq, options.WithRetryTimeout(timeout))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to Delete Net Peering.",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(netPeeringErrDelete, err.Error())
 	}
 }
 
-func (r *resourceNetPeering) read(ctx context.Context, data NetPeeringModel) (NetPeeringModel, error) {
+func (r *resourceNetPeering) read(ctx context.Context, timeout time.Duration, data NetPeeringModel) (NetPeeringModel, error) {
 	netPeeringFilters := osc.FiltersNetPeering{
 		NetPeeringIds: &[]string{data.NetPeeringId.ValueString()},
 	}
@@ -416,12 +419,7 @@ func (r *resourceNetPeering) read(ctx context.Context, data NetPeeringModel) (Ne
 		Filters: &netPeeringFilters,
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, ReadDefaultTimeout)
-	if diags.HasError() {
-		return data, fmt.Errorf("unable to parse 'net peering' read timeout value: %v", diags.Errors())
-	}
-
-	readResp, err := r.Client.ReadNetPeerings(ctx, readReq, options.WithRetryTimeout(readTimeout))
+	readResp, err := r.Client.ReadNetPeerings(ctx, readReq, options.WithRetryTimeout(timeout))
 	if err != nil {
 		return data, err
 	}
@@ -431,23 +429,28 @@ func (r *resourceNetPeering) read(ctx context.Context, data NetPeeringModel) (Ne
 	}
 
 	netPeering := (*readResp.NetPeerings)[0]
+
+	return r.flatten(ctx, data, netPeering)
+}
+
+func (r *resourceNetPeering) flatten(ctx context.Context, data NetPeeringModel, netPeering osc.NetPeering) (NetPeeringModel, error) {
 	tags, diag := flattenOAPITagsFW(ctx, netPeering.Tags)
 	if diag.HasError() {
-		return data, fmt.Errorf("unable to flatten tags: %v", diags.Errors())
+		return data, from.Diag(diag)
 	}
 	data.Tags = tags
 
 	sourceNet, diags := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: netAttrTypes}, SourceNetToList(netPeering.SourceNet))
 	if diags.HasError() {
-		return data, fmt.Errorf("unable to convert source net to the schema list: %v", diags.Errors())
+		return data, from.Diag(diags)
 	}
 	accepterNet, diags := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: netAttrTypes}, AccepterNetToList(netPeering.AccepterNet))
 	if diags.HasError() {
-		return data, fmt.Errorf("unable to convert accepter net to the schema list: %v", diags.Errors())
+		return data, from.Diag(diags)
 	}
 	state, diags := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: stateAttrTypes}, NetPeerStateToList(netPeering.State))
 	if diags.HasError() {
-		return data, fmt.Errorf("unable to convert state to the schema list: %v", diags.Errors())
+		return data, from.Diag(diags)
 	}
 
 	data.ExpirationDate = to.String(from.ISO8601(netPeering.ExpirationDate))
@@ -464,7 +467,7 @@ func (r *resourceNetPeering) read(ctx context.Context, data NetPeeringModel) (Ne
 	return data, nil
 }
 
-func (r *resourceNetPeering) stateRefreshFunc(id string) stateconf.StateRefreshFunc[osc.NetPeeringStateName] {
+func (r *resourceNetPeering) refreshFunc(id string) stateconf.StateRefreshFunc[osc.NetPeeringStateName] {
 	return func(ctx context.Context) (any, osc.NetPeeringStateName, error) {
 		readReq := osc.ReadNetPeeringsRequest{Filters: &osc.FiltersNetPeering{NetPeeringIds: &[]string{id}}}
 
@@ -481,6 +484,6 @@ func (r *resourceNetPeering) stateRefreshFunc(id string) stateconf.StateRefreshF
 			return nil, netPeering.State.Name, errors.New(netPeering.State.Message)
 		}
 
-		return resp, netPeering.State.Name, nil
+		return netPeering, netPeering.State.Name, nil
 	}
 }

--- a/internal/services/oapi/resource_net_peering_acceptation.go
+++ b/internal/services/oapi/resource_net_peering_acceptation.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -27,6 +28,10 @@ var (
 	_ resource.ResourceWithConfigure   = &resourceNetPeeringAcceptation{}
 	_ resource.ResourceWithImportState = &resourceNetPeeringAcceptation{}
 	_ resource.ResourceWithModifyPlan  = &resourceNetPeeringAcceptation{}
+)
+
+const (
+	netPeeringAcceptationErrCreate = "Unable to create Net Peering Acceptation"
 )
 
 type NetPeeringAcceptationModel struct {
@@ -174,7 +179,7 @@ func (r *resourceNetPeeringAcceptation) Create(ctx context.Context, req resource
 		return
 	}
 
-	createTimeout, diags := data.Timeouts.Create(ctx, CreateDefaultTimeout)
+	timeout, diags := data.Timeouts.Create(ctx, CreateDefaultTimeout)
 	if fwhelpers.CheckDiags(resp, diags) {
 		return
 	}
@@ -183,12 +188,9 @@ func (r *resourceNetPeeringAcceptation) Create(ctx context.Context, req resource
 		NetPeeringId: data.NetPeeringId.ValueString(),
 	}
 
-	createResp, err := r.Client.AcceptNetPeering(ctx, createReq, options.WithRetryTimeout(createTimeout))
+	createResp, err := r.Client.AcceptNetPeering(ctx, createReq, options.WithRetryTimeout(timeout))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to create Net Peering accepter.",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(netPeeringAcceptationErrCreate, err.Error())
 		return
 	}
 	data.RequestId = to.String(createResp.ResponseContext.RequestId)
@@ -196,15 +198,15 @@ func (r *resourceNetPeeringAcceptation) Create(ctx context.Context, req resource
 	data.NetPeeringId = to.String(netPeering.NetPeeringId)
 	data.Id = to.String(netPeering.NetPeeringId)
 
-	data, err = r.read(ctx, data)
+	// AcceptNetPeering reponse object seems incoherent with ReadNetPeering response.
+	// A read call is necessary to get the right object
+	stateData, err := r.read(ctx, timeout, data)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to set Net Peering Acceptation state",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateData)...)
 }
 
 func (r *resourceNetPeeringAcceptation) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -215,19 +217,21 @@ func (r *resourceNetPeeringAcceptation) Read(ctx context.Context, req resource.R
 		return
 	}
 
-	data, err := r.read(ctx, data)
+	timeout, diags := data.Timeouts.Read(ctx, ReadDefaultTimeout)
+	if fwhelpers.CheckDiags(resp, diags) {
+		return
+	}
+
+	stateData, err := r.read(ctx, timeout, data)
 	if err != nil {
 		if errors.Is(err, ErrResourceEmpty) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(
-			"Unable to set subnet API response values.",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateData)...)
 }
 
 func (r *resourceNetPeeringAcceptation) Update(context.Context, resource.UpdateRequest, *resource.UpdateResponse) {
@@ -237,7 +241,7 @@ func (r *resourceNetPeeringAcceptation) Delete(ctx context.Context, req resource
 	resp.State.RemoveResource(ctx)
 }
 
-func (r *resourceNetPeeringAcceptation) read(ctx context.Context, data NetPeeringAcceptationModel) (NetPeeringAcceptationModel, error) {
+func (r *resourceNetPeeringAcceptation) read(ctx context.Context, timeout time.Duration, data NetPeeringAcceptationModel) (NetPeeringAcceptationModel, error) {
 	netPeeringFilters := osc.FiltersNetPeering{
 		NetPeeringIds: &[]string{data.NetPeeringId.ValueString()},
 	}
@@ -245,12 +249,7 @@ func (r *resourceNetPeeringAcceptation) read(ctx context.Context, data NetPeerin
 		Filters: &netPeeringFilters,
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, ReadDefaultTimeout)
-	if diags.HasError() {
-		return data, fmt.Errorf("unable to parse 'net peering' read timeout value: %v", diags.Errors())
-	}
-
-	readResp, err := r.Client.ReadNetPeerings(ctx, readReq, options.WithRetryTimeout(readTimeout))
+	readResp, err := r.Client.ReadNetPeerings(ctx, readReq, options.WithRetryTimeout(timeout))
 	if err != nil || readResp.NetPeerings == nil {
 		return data, err
 	}
@@ -261,21 +260,25 @@ func (r *resourceNetPeeringAcceptation) read(ctx context.Context, data NetPeerin
 
 	netPeering := (*readResp.NetPeerings)[0]
 
+	return r.flatten(ctx, data, netPeering)
+}
+
+func (r *resourceNetPeeringAcceptation) flatten(ctx context.Context, data NetPeeringAcceptationModel, netPeering osc.NetPeering) (NetPeeringAcceptationModel, error) {
 	tags, diag := flattenOAPIComputedTagsFW(ctx, netPeering.Tags)
 	if diag.HasError() {
-		return data, fmt.Errorf("unable to convert tags to the schema list: %v", diags.Errors())
+		return data, from.Diag(diag)
 	}
 	sourceNet, diags := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: netAttrTypes}, SourceNetToList(netPeering.SourceNet))
 	if diags.HasError() {
-		return data, fmt.Errorf("unable to convert source net to the schema list: %v", diags.Errors())
+		return data, from.Diag(diags)
 	}
 	accepterNet, diags := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: netAttrTypes}, AccepterNetToList(netPeering.AccepterNet))
 	if diags.HasError() {
-		return data, fmt.Errorf("unable to convert accepter net to the schema list: %v", diags.Errors())
+		return data, from.Diag(diags)
 	}
 	state, diags := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: stateAttrTypes}, NetPeerStateToList(netPeering.State))
 	if diags.HasError() {
-		return data, fmt.Errorf("unable to convert state to the schema list: %v", diags.Errors())
+		return data, from.Diag(diags)
 	}
 
 	data.ExpirationDate = to.String(from.ISO8601(netPeering.ExpirationDate))

--- a/internal/services/oapi/resource_net_peering_test.go
+++ b/internal/services/oapi/resource_net_peering_test.go
@@ -2,6 +2,7 @@ package oapi_test
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/outscale/terraform-provider-outscale/internal/services/oapi/oapihelpers"
@@ -63,6 +64,25 @@ func TestAccNet_Peeringconnection_Migration(t *testing.T) {
 	})
 }
 
+func TestAccNet_PeeringConnection_CreateFailureKeepsState(t *testing.T) {
+	resourceName := "outscale_net_peering.foo"
+	invalidTagKey := strings.Repeat("a", 256)
+	tagValue := "testacc-net-peering"
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testacc.ProtoV6ProviderFactories(),
+		Steps: testacc.CreateFailureReplacementSteps(
+			resourceName,
+			testAccOAPIVpcPeeringConfigWithTag(invalidTagKey, tagValue),
+			testAccOAPIVpcPeeringConfigWithTag("Name", tagValue),
+			resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttrSet(resourceName, "net_peering_id"),
+				resource.TestCheckResourceAttr(resourceName, "tags.0.value", tagValue),
+			),
+		),
+	})
+}
+
 func testAccOAPIVpcPeeringConfig(accountid string) string {
 	return fmt.Sprintf(`
 	resource "outscale_net" "foo" {
@@ -116,4 +136,25 @@ func testAccOAPIVpcPeeringConfig2() string {
 		accepter_net_id = outscale_net.bar.id
 	}
 `
+}
+
+func testAccOAPIVpcPeeringConfigWithTag(tagKey, tagValue string) string {
+	return fmt.Sprintf(`
+	resource "outscale_net" "foo" {
+		ip_range = "10.0.0.0/16"
+	}
+
+	resource "outscale_net" "bar" {
+		ip_range = "10.1.0.0/16"
+	}
+
+	resource "outscale_net_peering" "foo" {
+		source_net_id   = outscale_net.foo.id
+		accepter_net_id = outscale_net.bar.id
+		tags {
+			key   = %q
+			value = %q
+		}
+	}
+`, tagKey, tagValue)
 }

--- a/internal/services/oapi/resource_net_test.go
+++ b/internal/services/oapi/resource_net_test.go
@@ -2,6 +2,7 @@ package oapi_test
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -51,6 +52,25 @@ func TestAccNet_UpdateTags(t *testing.T) {
 	})
 }
 
+func TestAccNet_CreateFailureKeepsState(t *testing.T) {
+	resourceName := "outscale_net.basic_net"
+	invalidTagKey := strings.Repeat("a", 256)
+	tagValue := "testacc-net"
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testacc.ProtoV6ProviderFactories(),
+		Steps: testacc.CreateFailureReplacementSteps(
+			resourceName,
+			configNetUpdateTagsWithKey(invalidTagKey, tagValue),
+			configNetUpdateTags(tagValue),
+			resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttrSet(resourceName, "net_id"),
+				resource.TestCheckResourceAttr(resourceName, "tags.0.value", tagValue),
+			),
+		),
+	})
+}
+
 const configNetBasic = `
 	resource "outscale_net" "basic_net" {
 		ip_range = "10.0.0.0/16"
@@ -62,13 +82,17 @@ const configNetBasic = `
 `
 
 func configNetUpdateTags(tagValue string) string {
+	return configNetUpdateTagsWithKey("name", tagValue)
+}
+
+func configNetUpdateTagsWithKey(tagKey, tagValue string) string {
 	return fmt.Sprintf(`
 	resource "outscale_net" "basic_net" {
 		ip_range = "10.0.0.0/16"
 		tags {
-			key = "name"
+			key = "%s"
 			value = "%s"
 		}
 	   }
-`, tagValue)
+`, tagKey, tagValue)
 }

--- a/internal/services/oapi/resource_outscale_image.go
+++ b/internal/services/oapi/resource_outscale_image.go
@@ -302,11 +302,8 @@ func resourceOAPIImageCreate(ctx context.Context, d *schema.ResourceData, meta a
 		return diag.FromErr(err)
 	}
 
-	if resp.Image == nil {
-		return nil
-	}
-
 	image := ptr.From(resp.Image)
+	d.SetId(image.ImageId)
 
 	log.Printf("[DEBUG] Waiting for OMI %s to become available...", image.ImageId)
 
@@ -322,7 +319,6 @@ func resourceOAPIImageCreate(ctx context.Context, d *schema.ResourceData, meta a
 	if _, err = stateConf.WaitForStateContext(ctx); err != nil {
 		return diag.Errorf("error waiting for omi (%s) to be ready: %v", image.ImageId, err)
 	}
-	d.SetId(image.ImageId)
 
 	err = createOAPITagsSDK(ctx, client, timeout, d)
 	if err != nil {

--- a/internal/services/oapi/resource_outscale_image_export_task.go
+++ b/internal/services/oapi/resource_outscale_image_export_task.go
@@ -172,6 +172,7 @@ func resourceOAPIImageExportTaskCreate(ctx context.Context, d *schema.ResourceDa
 	}
 
 	id := *resp.ImageExportTask.TaskId
+	d.SetId(id)
 
 	wait := d.Get("wait_for_completion").(bool)
 	if wait {
@@ -181,7 +182,6 @@ func resourceOAPIImageExportTaskCreate(ctx context.Context, d *schema.ResourceDa
 		}
 	}
 
-	d.SetId(id)
 	if d.IsNewResource() {
 		if err := updateOAPITagsSDK(ctx, client, timeout, d); err != nil {
 			return diag.FromErr(err)

--- a/internal/services/oapi/resource_outscale_image_test.go
+++ b/internal/services/oapi/resource_outscale_image_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -42,6 +43,30 @@ func TestAccOthers_Image_basic(t *testing.T) {
 				),
 			},
 		},
+	})
+}
+
+func TestAccOthers_Image_CreateFailureKeepsState(t *testing.T) {
+	omi := os.Getenv("OUTSCALE_IMAGEID")
+	region := utils.GetRegion()
+	sgName := acctest.RandomWithPrefix("testacc-sg")
+	rInt := acctest.RandInt()
+	invalidTagKey := strings.Repeat("a", 256)
+	tagValue := "testacc-resource-image"
+	resourceName := "outscale_image.foo"
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testacc.ProtoV6ProviderFactories(),
+		CheckDestroy:             testAccCheckOAPIImageDestroy,
+		Steps: testacc.CreateFailureReplacementSteps(
+			resourceName,
+			testAccOAPIImageConfigWithTag(omi, testAccVmType, region, rInt, sgName, invalidTagKey, tagValue),
+			testAccOAPIImageConfigWithTag(omi, testAccVmType, region, rInt, sgName, "Name", tagValue),
+			resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttrSet(resourceName, "id"),
+				resource.TestCheckResourceAttr(resourceName, "tags.0.value", tagValue),
+			),
+		),
 	})
 }
 
@@ -94,13 +119,17 @@ func testAccCheckOAPIImageExists(ctx context.Context, n string, ami *osc.Image) 
 }
 
 func testAccOAPIImageConfigBasic(omi, vmType, region string, rInt int, sgName string) string {
+	return testAccOAPIImageConfigWithTag(omi, vmType, region, rInt, sgName, "Name", "tf-acc-test")
+}
+
+func testAccOAPIImageConfigWithTag(omi, vmType, region string, rInt int, sgName, tagKey, tagValue string) string {
 	return fmt.Sprintf(`
 		resource "outscale_security_group" "sg_img" {
 			security_group_name = "%[5]s"
 			description         = "Used in the terraform acceptance tests"
- 			tags {
-				key   = "Name"
-				value = "tf-acc-test"
+  			tags {
+				key   = "%[6]s"
+				value = "%[7]s"
 			}
 		}
 
@@ -124,6 +153,10 @@ func testAccOAPIImageConfigBasic(omi, vmType, region string, rInt int, sgName st
 			description = "terraform testing"
                         root_device_name="/dev/sda1"
                         architecture = "x86_64"
+			tags {
+				key   = "%[6]s"
+				value = "%[7]s"
+			}
                         block_device_mappings {
                           bsu  {
                             snapshot_id = outscale_snapshot.snap_image.snapshot_id
@@ -132,5 +165,5 @@ func testAccOAPIImageConfigBasic(omi, vmType, region string, rInt int, sgName st
                          device_name = "/dev/sda1"
                       }
 		}
-	`, omi, vmType, region, rInt, sgName)
+	`, omi, vmType, region, rInt, sgName, tagKey, tagValue)
 }

--- a/internal/services/oapi/resource_outscale_load_balancer.go
+++ b/internal/services/oapi/resource_outscale_load_balancer.go
@@ -464,7 +464,7 @@ func ResourceOutscaleLoadBalancerCreate(ctx context.Context, d *schema.ResourceD
 		}
 	}
 
-	err = waitForLbuActive(ctx, client, d.Id(), timeout)
+	_, err = waitForLbuActive(ctx, client, d.Id(), timeout)
 	if err != nil {
 		return diag.Errorf("error waiting for load balancer (%s) to be ready: %s", d.Id(), err)
 	}
@@ -472,7 +472,7 @@ func ResourceOutscaleLoadBalancerCreate(ctx context.Context, d *schema.ResourceD
 	return ResourceOutscaleLoadBalancerRead(ctx, d, meta)
 }
 
-func waitForLbuActive(ctx context.Context, client *osc.Client, lbuName string, timeout time.Duration) error {
+func waitForLbuActive(ctx context.Context, client *osc.Client, lbuName string, timeout time.Duration) (*osc.LoadBalancer, error) {
 	stateConf := &retry.StateChangeConf{
 		Pending: []string{string(osc.LoadBalancerStateStarting), string(osc.LoadBalancerStateProvisioning), string(osc.LoadBalancerStateReloading), string(osc.LoadBalancerStateReconfiguring)},
 		Target:  []string{string(osc.LoadBalancerStateActive)},
@@ -485,8 +485,12 @@ func waitForLbuActive(ctx context.Context, client *osc.Client, lbuName string, t
 		},
 		Timeout: timeout,
 	}
-	_, err := stateConf.WaitForStateContext(ctx)
-	return err
+	lbuAny, err := stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return lbuAny.(*osc.LoadBalancer), nil
 }
 
 func readResourceLb(ctx context.Context, client *osc.Client, elbName string, timeout time.Duration) (*osc.LoadBalancer, *osc.ReadLoadBalancersResponse, error) {
@@ -652,7 +656,7 @@ func ResourceOutscaleLoadBalancerUpdate(ctx context.Context, d *schema.ResourceD
 		if err != nil {
 			return diag.Errorf("failure updating securitygroups: %v", err)
 		}
-		err = waitForLbuActive(ctx, client, d.Id(), timeout)
+		_, err = waitForLbuActive(ctx, client, d.Id(), timeout)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -754,7 +758,7 @@ func ResourceOutscaleLoadBalancerUpdate(ctx context.Context, d *schema.ResourceD
 				return diag.Errorf("failure adding new or updated load balancer listeners: %v", err)
 			}
 		}
-		err = waitForLbuActive(ctx, client, d.Id(), timeout)
+		_, err = waitForLbuActive(ctx, client, d.Id(), timeout)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -784,7 +788,7 @@ func ResourceOutscaleLoadBalancerUpdate(ctx context.Context, d *schema.ResourceD
 			if err != nil {
 				return diag.Errorf("failure configuring health check for load balancer: %v", err)
 			}
-			err = waitForLbuActive(ctx, client, d.Id(), timeout)
+			_, err = waitForLbuActive(ctx, client, d.Id(), timeout)
 			if err != nil {
 				return diag.FromErr(err)
 			}
@@ -813,7 +817,7 @@ func ResourceOutscaleLoadBalancerUpdate(ctx context.Context, d *schema.ResourceD
 			if err != nil {
 				return diag.Errorf("failure configuring access log for load balancer: %v", err)
 			}
-			err = waitForLbuActive(ctx, client, d.Id(), timeout)
+			_, err = waitForLbuActive(ctx, client, d.Id(), timeout)
 			if err != nil {
 				return diag.FromErr(err)
 			}
@@ -830,7 +834,7 @@ func ResourceOutscaleLoadBalancerUpdate(ctx context.Context, d *schema.ResourceD
 		if err != nil {
 			return diag.Errorf("failure updating secruedcookies: %v", err)
 		}
-		err = waitForLbuActive(ctx, client, d.Id(), timeout)
+		_, err = waitForLbuActive(ctx, client, d.Id(), timeout)
 		if err != nil {
 			return diag.FromErr(err)
 		}

--- a/internal/services/oapi/resource_outscale_load_balancer_attributes.go
+++ b/internal/services/oapi/resource_outscale_load_balancer_attributes.go
@@ -323,11 +323,12 @@ func ResourceOutscaleLoadBalancerAttributesCreate_(ctx context.Context, d *schem
 		req.PolicyNames = &a
 	}
 	if isUpdate {
-		err := loadBalancerAttributesDoRequest(ctx, d, meta, req, timeout)
-		if err != nil {
-			return err
+		diags := loadBalancerAttributesDoRequest(ctx, d, meta, req, timeout)
+		if diags != nil {
+			return diags
 		}
-		return diag.FromErr(waitForLbuActive(ctx, conn, ename.(string), timeout))
+		_, err := waitForLbuActive(ctx, conn, ename.(string), timeout)
+		return diag.FromErr(err)
 	}
 
 	if ssl, sok := d.GetOk("server_certificate_id"); sok {
@@ -386,12 +387,13 @@ func ResourceOutscaleLoadBalancerAttributesCreate_(ctx context.Context, d *schem
 		req.HealthCheck = &healthCheck
 	}
 
-	err := loadBalancerAttributesDoRequest(ctx, d, meta, req, timeout)
-	if err != nil {
-		return err
+	diags := loadBalancerAttributesDoRequest(ctx, d, meta, req, timeout)
+	if diags != nil {
+		return diags
 	}
 
-	return diag.FromErr(waitForLbuActive(ctx, conn, ename.(string), timeout))
+	_, err := waitForLbuActive(ctx, conn, ename.(string), timeout)
+	return diag.FromErr(err)
 }
 
 func ResourceOutscaleLoadBalancerAttributesRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/services/oapi/resource_outscale_nic_test.go
+++ b/internal/services/oapi/resource_outscale_nic_test.go
@@ -2,6 +2,7 @@ package oapi_test
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/outscale/terraform-provider-outscale/internal/testacc"
@@ -38,7 +39,42 @@ func TestAccNet_WithNic_basic(t *testing.T) {
 	})
 }
 
+func TestAccNet_WithNic_CreateFailureKeepsState(t *testing.T) {
+	subregion := utils.GetRegion()
+	resourceName := "outscale_nic.outscale_nic"
+	sgName := acctest.RandomWithPrefix("testacc-sg")
+	invalidTagKey := strings.Repeat("a", 256)
+	tagValue := "testacc-resource-nic"
+
+	resource.ParallelTest(t, resource.TestCase{
+		IDRefreshName:            resourceName,
+		ProtoV6ProviderFactories: testacc.ProtoV6ProviderFactories(),
+		Steps: testacc.CreateFailureReplacementSteps(
+			resourceName,
+			testAccOutscaleENIConfigWithTag(subregion, sgName, invalidTagKey, tagValue),
+			testAccOutscaleENIConfigWithTag(subregion, sgName, "name", tagValue),
+			resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttrSet(resourceName, "nic_id"),
+				resource.TestCheckResourceAttr(resourceName, "tags.0.value", tagValue),
+			),
+		),
+	})
+}
+
 func testAccOutscaleENIConfig(subregion, sgName string) string {
+	return testAccOutscaleENIConfigWithTag(subregion, sgName, "", "")
+}
+
+func testAccOutscaleENIConfigWithTag(subregion, sgName, tagKey, tagValue string) string {
+	tags := ""
+	if tagKey != "" {
+		tags = fmt.Sprintf(`
+			tags {
+				key   = %q
+				value = %q
+			}
+		`, tagKey, tagValue)
+	}
 	return fmt.Sprintf(`
 		resource "outscale_net" "outscale_net" {
 			ip_range = "10.0.0.0/16"
@@ -73,8 +109,10 @@ func testAccOutscaleENIConfig(subregion, sgName string) string {
 				is_primary = false
 				private_ip = "10.0.0.46"
 			}
+
+			%s
 		}
-	`, subregion, sgName)
+	`, subregion, sgName, tags)
 }
 
 func testAccOutscaleENIConfigUpdate(subregion, sgName string) string {

--- a/internal/services/oapi/resource_outscale_snapshot_export_task.go
+++ b/internal/services/oapi/resource_outscale_snapshot_export_task.go
@@ -165,6 +165,7 @@ func resourceOAPISnapshotExportTaskCreate(ctx context.Context, d *schema.Resourc
 	}
 
 	id := resp.SnapshotExportTask.TaskId
+	d.SetId(id)
 
 	wait := d.Get("wait_for_completion").(bool)
 	if wait {
@@ -174,7 +175,6 @@ func resourceOAPISnapshotExportTaskCreate(ctx context.Context, d *schema.Resourc
 		}
 	}
 
-	d.SetId(id)
 	if d.IsNewResource() {
 		if err := updateOAPITagsSDK(ctx, client, timeout, d); err != nil {
 			return diag.FromErr(err)

--- a/internal/services/oapi/resource_outscale_virtual_gateway.go
+++ b/internal/services/oapi/resource_outscale_virtual_gateway.go
@@ -91,11 +91,14 @@ func ResourceOutscaleVirtualGatewayCreate(ctx context.Context, d *schema.Resourc
 		return diag.Errorf("error creating vpn gateway: %s", err)
 	}
 
+	virtualGatewayID := ptr.From(resp.VirtualGateway).VirtualGatewayId
+	d.SetId(virtualGatewayID)
+
 	stateConf := &retry.StateChangeConf{
 		Pending: []string{"pending"},
 		Target:  []string{"available"},
 		Timeout: timeout,
-		Refresh: virtualGatewayStateRefreshFunc(ctx, client, resp.VirtualGateway.VirtualGatewayId, "deleted", timeout),
+		Refresh: virtualGatewayStateRefreshFunc(ctx, client, virtualGatewayID, "deleted", timeout),
 	}
 
 	_, err = stateConf.WaitForStateContext(ctx)
@@ -103,9 +106,6 @@ func ResourceOutscaleVirtualGatewayCreate(ctx context.Context, d *schema.Resourc
 		return diag.Errorf(
 			"error waiting for instance (%s) to become created: %s", d.Id(), err)
 	}
-
-	virtualGateway := resp.VirtualGateway
-	d.SetId(virtualGateway.VirtualGatewayId)
 
 	if d.IsNewResource() {
 		if err := updateOAPITagsSDK(ctx, client, timeout, d); err != nil {

--- a/internal/services/oapi/resource_outscale_virtual_gateway_link.go
+++ b/internal/services/oapi/resource_outscale_virtual_gateway_link.go
@@ -92,6 +92,8 @@ func ResourceOutscaleVirtualGatewayLinkCreate(ctx context.Context, d *schema.Res
 			vgwID, netID, err)
 	}
 
+	d.SetId(vgwID)
+
 	stateConf := &retry.StateChangeConf{
 		Pending: []string{"detached", "attaching"},
 		Target:  []string{"attached"},
@@ -105,8 +107,6 @@ func ResourceOutscaleVirtualGatewayLinkCreate(ctx context.Context, d *schema.Res
 			vgwID, netID, err)
 	}
 	log.Printf("[DEBUG] Virtual Gateway %q attached to VPC %q.", vgwID, netID)
-
-	d.SetId(vgwID)
 
 	return ResourceOutscaleVirtualGatewayLinkRead(ctx, d, meta)
 }

--- a/internal/services/oapi/resource_outscale_virtual_gateway_test.go
+++ b/internal/services/oapi/resource_outscale_virtual_gateway_test.go
@@ -2,6 +2,7 @@ package oapi_test
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -38,20 +39,40 @@ func TestAccOthers_VirtualGatewayChangeTags(t *testing.T) {
 		Providers: testacc.SDKProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccOAPIVirtualGatewayConfigChangeTags("ipsec.1", "test-VGW"),
+				Config: testAccOAPIVirtualGatewayConfigChangeTags("ipsec.1", "name", "test-VGW"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "tags.#"),
 					resource.TestCheckResourceAttr(resourceName, "tags.0.value", "test-VGW"),
 				),
 			},
 			{
-				Config: testAccOAPIVirtualGatewayConfigChangeTags("ipsec.1", "test-VGW2"),
+				Config: testAccOAPIVirtualGatewayConfigChangeTags("ipsec.1", "name", "test-VGW2"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "tags.#"),
 					resource.TestCheckResourceAttr(resourceName, "tags.0.value", "test-VGW2"),
 				),
 			},
 		},
+	})
+}
+
+func TestAccOthers_VirtualGateway_CreateFailureKeepsState(t *testing.T) {
+	resourceName := "outscale_virtual_gateway.outscale_virtual_gateway"
+	invalidTagKey := strings.Repeat("a", 256)
+	tagValue := "testacc-resource-virtual-gateway"
+
+	resource.ParallelTest(t, resource.TestCase{
+		Providers: testacc.SDKProviders,
+		Steps: testacc.CreateFailureReplacementSteps(
+			resourceName,
+			testAccOAPIVirtualGatewayConfigChangeTags("ipsec.1", invalidTagKey, tagValue),
+			testAccOAPIVirtualGatewayConfigChangeTags("ipsec.1", "name", tagValue),
+			resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttrSet(resourceName, "virtual_gateway_id"),
+				resource.TestCheckResourceAttrSet(resourceName, "tags.#"),
+				resource.TestCheckResourceAttr(resourceName, "tags.0.value", tagValue),
+			),
+		),
 	})
 }
 
@@ -88,15 +109,15 @@ const testAccOAPIVirtualGatewayConfigChangeVPC = `
     }
 `
 
-func testAccOAPIVirtualGatewayConfigChangeTags(connectionType, name string) string {
+func testAccOAPIVirtualGatewayConfigChangeTags(connectionType, tagKey, tagValue string) string {
 	return fmt.Sprintf(`
 		resource "outscale_virtual_gateway" "outscale_virtual_gateway" {
 		 connection_type = "%s"
 		 tags {
-		  key = "name"
-		  value = "%s"
+		  key = %q
+		  value = %q
 		  }
 		}
 
-	`, connectionType, name)
+	`, connectionType, tagKey, tagValue)
 }

--- a/internal/services/oapi/resource_outscale_vm.go
+++ b/internal/services/oapi/resource_outscale_vm.go
@@ -1288,10 +1288,13 @@ func resourceOAPIVMDelete(ctx context.Context, d *schema.ResourceData, meta any)
 	timeout := d.Timeout(schema.TimeoutDelete)
 	id := d.Id()
 
-	_, err := client.StopVms(ctx, osc.StopVmsRequest{
-		VmIds:     []string{id},
-		ForceStop: new(true),
-	}, options.WithRetryTimeout(timeout))
+	// The API returns a 409 with code "9039" when the VM is still pending from creation
+	_, err := oapihelpers.RetryOnCodes(ctx, []string{"9039"}, func() (resp any, err error) {
+		return client.StopVms(ctx, osc.StopVmsRequest{
+			VmIds:     []string{id},
+			ForceStop: new(true),
+		}, options.WithRetryTimeout(timeout))
+	}, timeout)
 	if err != nil {
 		return diag.Errorf("error force stopping vms before destroy %s", err)
 	}
@@ -1647,7 +1650,7 @@ func startVM(ctx context.Context, client *osc.Client, timeout time.Duration, id 
 		VmIds: []string{id},
 	}, options.WithRetryTimeout(timeout))
 	if err != nil {
-		return fmt.Errorf("error starting vm %w", err)
+		return fmt.Errorf("error starting vm: %w", err)
 	}
 
 	stateConf := &retry.StateChangeConf{

--- a/internal/services/oapi/resource_outscale_vm_test.go
+++ b/internal/services/oapi/resource_outscale_vm_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -42,6 +43,30 @@ func TestAccVM_Basic(t *testing.T) {
 				),
 			},
 		},
+	})
+}
+
+func TestAccVM_CreateFailureKeepsState(t *testing.T) {
+	resourceName := "outscale_vm.basic_tags"
+	omi := os.Getenv("OUTSCALE_IMAGEID")
+	keypair := "terraform-basic"
+	region := utils.GetRegion()
+	sgName := acctest.RandomWithPrefix("testacc-sg")
+	invalidTagKey := strings.Repeat("a", 256)
+	tagValue := "testacc-resource-vm"
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testacc.ProtoV6ProviderFactories(),
+		CheckDestroy:             testAccCheckOutscaleVMDestroy,
+		Steps: testacc.CreateFailureReplacementSteps(
+			resourceName,
+			testAccVmsConfigWithTag(omi, testAccVmType, region, invalidTagKey, tagValue, keypair, sgName),
+			testAccVmsConfigWithTag(omi, testAccVmType, region, "name", tagValue, keypair, sgName),
+			resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttrSet(resourceName, "id"),
+				resource.TestCheckResourceAttr(resourceName, "tags.0.value", tagValue),
+			),
+		),
 	})
 }
 
@@ -897,26 +922,30 @@ func testAccVmsConfigUpdateOAPIVMKey2(omi, vmType, region, keypair, newKeypair, 
 }
 
 func testAccVmsConfigUpdateOAPIVMTags(omi, vmType, region, value, keypair, sgName string) string {
+	return testAccVmsConfigWithTag(omi, vmType, region, "name", value, keypair, sgName)
+}
+
+func testAccVmsConfigWithTag(omi, vmType, region, tagKey, tagValue, keypair, sgName string) string {
 	return fmt.Sprintf(`
 		resource "outscale_security_group" "sg_tags_vm" {
 			description                  = "testAcc Terraform security group"
-			security_group_name          = "%[6]s"
+			security_group_name          = %q
 		}
 		resource "outscale_vm" "basic_tags" {
-			image_id                 = "%[1]s"
-			vm_type                  = "%[2]s"
-			keypair_name             = "%[5]s"
-			placement_subregion_name = "%[3]sb"
+			image_id                 = %q
+			vm_type                  = %q
+			keypair_name             = %q
+			placement_subregion_name = %q
 			security_group_ids = [outscale_security_group.sg_tags_vm.security_group_id]
 
 			tags {
-				key   = "name"
-				value = "%[4]s"
+				key   = %q
+				value = %q
 			}
 
 			lifecycle { ignore_changes = [state] }
 		}
-	`, omi, vmType, region, value, keypair, sgName)
+	`, sgName, omi, vmType, keypair, region+"a", tagKey, tagValue)
 }
 
 func testAccCheckOutscaleVMConfigWithSubnet(omi, vmType, region, keypair, sgName string) string {

--- a/internal/services/oapi/resource_policy.go
+++ b/internal/services/oapi/resource_policy.go
@@ -29,6 +29,13 @@ var (
 	_ resource.ResourceWithModifyPlan  = &resourcePolicy{}
 )
 
+const (
+	policyErrCreate         = "Unable to create Policy"
+	policyErrDelete         = "Unable to delete Policy"
+	policyErrUnlink         = "Unable to unlink entities from Policy"
+	policyErrDeleteVersions = "Unable to delete versions linked to Policy"
+)
+
 type PolicyModel struct {
 	CreationDate           types.String   `tfsdk:"creation_date"`
 	Description            types.String   `tfsdk:"description"`
@@ -162,7 +169,7 @@ func (r *resourcePolicy) Create(ctx context.Context, req resource.CreateRequest,
 	var data PolicyModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
 
-	createTimeout, diag := data.Timeouts.Create(ctx, CreateDefaultTimeout)
+	timeout, diag := data.Timeouts.Create(ctx, CreateDefaultTimeout)
 	if fwhelpers.CheckDiags(resp, diag) {
 		return
 	}
@@ -179,24 +186,19 @@ func (r *resourcePolicy) Create(ctx context.Context, req resource.CreateRequest,
 		createReq.Description = data.Description.ValueStringPointer()
 	}
 
-	createResp, err := r.Client.CreatePolicy(ctx, createReq, options.WithRetryTimeout(createTimeout))
+	createResp, err := r.Client.CreatePolicy(ctx, createReq, options.WithRetryTimeout(timeout))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to create Policy",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(policyErrCreate, err.Error())
 		return
 	}
 	policy := ptr.From(createResp.Policy)
-
 	data.Id = to.String(policy.Orn)
+	// The API response contains the policy object, but the flatten operation would need to make another API call to get the full state,
+	// which seems counter-productive. The next read call will get the full state
 
-	stateData, err := r.read(ctx, createTimeout, data)
+	stateData, err := r.read(ctx, timeout, data)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to set Policy state",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
@@ -207,21 +209,18 @@ func (r *resourcePolicy) Read(ctx context.Context, req resource.ReadRequest, res
 	var data PolicyModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
 
-	readTimeout, diag := data.Timeouts.Read(ctx, ReadDefaultTimeout)
+	timeout, diag := data.Timeouts.Read(ctx, ReadDefaultTimeout)
 	if fwhelpers.CheckDiags(resp, diag) {
 		return
 	}
 
-	stateData, err := r.read(ctx, readTimeout, data)
+	stateData, err := r.read(ctx, timeout, data)
 	if err != nil {
 		if errors.Is(err, ErrResourceEmpty) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(
-			"Unable to set Policy API response values",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
@@ -235,26 +234,20 @@ func (r *resourcePolicy) Delete(ctx context.Context, req resource.DeleteRequest,
 	var data PolicyModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
 
-	deleteTimeout, diag := data.Timeouts.Delete(ctx, DeleteDefaultTimeout)
+	timeout, diag := data.Timeouts.Delete(ctx, DeleteDefaultTimeout)
 	if fwhelpers.CheckDiags(resp, diag) {
 		return
 	}
 
-	err := r.unlinkEntities(ctx, deleteTimeout, data.Orn.ValueString())
+	err := r.unlinkEntities(ctx, timeout, data.Orn.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to unlink entities from Policy",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(policyErrUnlink, err.Error())
 		return
 	}
 
-	err = r.deleteVersions(ctx, deleteTimeout, data.Orn.ValueString())
+	err = r.deleteVersions(ctx, timeout, data.Orn.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to delete versions linked to Policy",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(policyErrDeleteVersions, err.Error())
 		return
 	}
 
@@ -262,12 +255,9 @@ func (r *resourcePolicy) Delete(ctx context.Context, req resource.DeleteRequest,
 		PolicyOrn: data.Orn.ValueString(),
 	}
 
-	_, err = r.Client.DeletePolicy(ctx, delReq, options.WithRetryTimeout(deleteTimeout))
+	_, err = r.Client.DeletePolicy(ctx, delReq, options.WithRetryTimeout(timeout))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to delete Policy",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(policyErrDelete, err.Error())
 	}
 }
 

--- a/internal/services/oapi/resource_policy_version.go
+++ b/internal/services/oapi/resource_policy_version.go
@@ -28,6 +28,12 @@ var (
 	_ resource.ResourceWithConfigure = &resourcePolicyVersion{}
 )
 
+const (
+	policyVersionErrCreate     = "Unable to create Policy Version"
+	policyVersionErrDelete     = "Unable to delete Policy Version"
+	policyVersionErrSetDefault = "Unable to set Policy Version v1 as default before deletion"
+)
+
 type PolicyVersionModel struct {
 	Body           types.String   `tfsdk:"body"`
 	CreationDate   types.String   `tfsdk:"creation_date"`
@@ -128,7 +134,7 @@ func (r *resourcePolicyVersion) Create(ctx context.Context, req resource.CreateR
 	var data PolicyVersionModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
 
-	createTimeout, diag := data.Timeouts.Create(ctx, CreateDefaultTimeout)
+	timeout, diag := data.Timeouts.Create(ctx, CreateDefaultTimeout)
 	if fwhelpers.CheckDiags(resp, diag) {
 		return
 	}
@@ -142,26 +148,16 @@ func (r *resourcePolicyVersion) Create(ctx context.Context, req resource.CreateR
 		createReq.SetAsDefault = data.SetAsDefault.ValueBoolPointer()
 	}
 
-	createResp, err := r.Client.CreatePolicyVersion(ctx, createReq, options.WithRetryTimeout(createTimeout))
+	createResp, err := r.Client.CreatePolicyVersion(ctx, createReq, options.WithRetryTimeout(timeout))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to create Policy Version",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(policyVersionErrCreate, err.Error())
 		return
 	}
 	policyVersion := ptr.From(createResp.PolicyVersion)
 	data.Id = to.String(id.UniqueId())
 	data.VersionId = to.String(policyVersion.VersionId)
 
-	stateData, err := r.read(ctx, createTimeout, data)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to set Policy Version state",
-			err.Error(),
-		)
-		return
-	}
+	stateData := r.flatten(data, policyVersion)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &stateData)...)
 }
@@ -181,10 +177,7 @@ func (r *resourcePolicyVersion) Read(ctx context.Context, req resource.ReadReque
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(
-			"Unable to set Policy Version state",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
@@ -198,22 +191,19 @@ func (r *resourcePolicyVersion) Delete(ctx context.Context, req resource.DeleteR
 	var data PolicyVersionModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
 
-	deleteTimeout, diag := data.Timeouts.Delete(ctx, DeleteDefaultTimeout)
+	timeout, diag := data.Timeouts.Delete(ctx, DeleteDefaultTimeout)
 	if fwhelpers.CheckDiags(resp, diag) {
 		return
 	}
 
 	// Refresh state to check current default version status
 	// This is necessary because user/user_group resources can change the default version
-	stateData, err := r.read(ctx, deleteTimeout, data)
+	stateData, err := r.read(ctx, timeout, data)
 	if err != nil {
 		if errors.Is(err, ErrResourceEmpty) {
 			return
 		}
-		resp.Diagnostics.AddError(
-			"Unable to refresh Policy Version state before deletion",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 	data = stateData
@@ -224,12 +214,9 @@ func (r *resourcePolicyVersion) Delete(ctx context.Context, req resource.DeleteR
 			PolicyOrn: data.PolicyOrn.ValueString(),
 			VersionId: "v1",
 		}
-		_, err := r.Client.SetDefaultPolicyVersion(ctx, req, options.WithRetryTimeout(deleteTimeout))
+		_, err := r.Client.SetDefaultPolicyVersion(ctx, req, options.WithRetryTimeout(timeout))
 		if err != nil {
-			resp.Diagnostics.AddError(
-				"Unable to set Policy Version v1 as default before deletion",
-				err.Error(),
-			)
+			resp.Diagnostics.AddError(policyVersionErrSetDefault, err.Error())
 			return
 		}
 	}
@@ -238,12 +225,9 @@ func (r *resourcePolicyVersion) Delete(ctx context.Context, req resource.DeleteR
 		PolicyOrn: data.PolicyOrn.ValueString(),
 		VersionId: data.VersionId.ValueString(),
 	}
-	_, err = r.Client.DeletePolicyVersion(ctx, deleteReq, options.WithRetryTimeout(deleteTimeout))
+	_, err = r.Client.DeletePolicyVersion(ctx, deleteReq, options.WithRetryTimeout(timeout))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to delete Policy Version",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(policyVersionErrDelete, err.Error())
 	}
 }
 
@@ -263,9 +247,13 @@ func (r *resourcePolicyVersion) read(ctx context.Context, timeout time.Duration,
 
 	policyVersion := ptr.From(resp.PolicyVersion)
 
+	return r.flatten(data, policyVersion), nil
+}
+
+func (r *resourcePolicyVersion) flatten(data PolicyVersionModel, policyVersion osc.PolicyVersion) PolicyVersionModel {
 	data.DefaultVersion = to.Bool(policyVersion.DefaultVersion)
 	data.CreationDate = to.String(from.ISO8601(policyVersion.CreationDate))
 	data.Body = to.String(policyVersion.Body)
 
-	return data, nil
+	return data
 }

--- a/internal/services/oapi/resource_public_ip.go
+++ b/internal/services/oapi/resource_public_ip.go
@@ -18,6 +18,7 @@ import (
 	"github.com/outscale/osc-sdk-go/v3/pkg/osc"
 	"github.com/outscale/terraform-provider-outscale/internal/client"
 	"github.com/outscale/terraform-provider-outscale/internal/framework/fwhelpers"
+	"github.com/outscale/terraform-provider-outscale/internal/framework/fwhelpers/from"
 	"github.com/outscale/terraform-provider-outscale/internal/framework/fwhelpers/to"
 )
 
@@ -29,10 +30,8 @@ var (
 
 const (
 	publicIpErrCreate = "Unable to create Public IP"
-	publicIpErrRead   = "Unable to read Public IP"
 	publicIpErrDelete = "Unable to delete Public IP"
 	publicIpErrUnlink = "Unable to unlink Public IP from VM or NIC"
-	publicIpErrState  = "Unable to set Public IP state"
 )
 
 type publicIpModel struct {
@@ -170,17 +169,28 @@ func (r *publicIpResource) Create(ctx context.Context, req resource.CreateReques
 		return
 	}
 
+	data.RequestId = to.String(createResp.ResponseContext.RequestId)
 	data.Id = to.String(createResp.PublicIp.PublicIpId)
 	data.PublicIpId = to.String(createResp.PublicIp.PublicIpId)
+
+	stateData, err := r.flatten(ctx, data, *createResp.PublicIp)
+	if err != nil {
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
+		return
+	}
+	diags = resp.State.Set(ctx, &stateData)
+	if fwhelpers.CheckDiags(resp, diags) {
+		return
+	}
 
 	diag := createOAPITagsFW(ctx, r.Client, timeout, data.Tags, createResp.PublicIp.PublicIpId)
 	if fwhelpers.CheckDiags(resp, diag) {
 		return
 	}
 
-	stateData, err := r.read(ctx, timeout, data)
+	stateData, err = r.read(ctx, timeout, data)
 	if err != nil {
-		resp.Diagnostics.AddError(publicIpErrState, err.Error())
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
@@ -202,7 +212,7 @@ func (r *publicIpResource) Read(ctx context.Context, req resource.ReadRequest, r
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(publicIpErrRead, err.Error())
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
@@ -233,7 +243,7 @@ func (r *publicIpResource) Update(ctx context.Context, req resource.UpdateReques
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(publicIpErrState, err.Error())
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
@@ -258,7 +268,7 @@ func (r *publicIpResource) Delete(ctx context.Context, req resource.DeleteReques
 		if errors.Is(err, ErrResourceEmpty) {
 			return
 		}
-		resp.Diagnostics.AddError(publicIpErrRead, err.Error())
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
@@ -305,14 +315,18 @@ func (r *publicIpResource) read(ctx context.Context, timeout time.Duration, data
 	}
 
 	publicIp := (*resp.PublicIps)[0]
+	data.RequestId = to.String(resp.ResponseContext.RequestId)
 
+	return r.flatten(ctx, data, publicIp)
+}
+
+func (r *publicIpResource) flatten(ctx context.Context, data publicIpModel, publicIp osc.PublicIp) (publicIpModel, error) {
 	tags, diag := flattenOAPITagsFW(ctx, publicIp.Tags)
 	if diag.HasError() {
-		return data, fmt.Errorf("unable to flatten tags: %v", diag.Errors())
+		return data, from.Diag(diag)
 	}
 
 	data.Tags = tags
-	data.RequestId = to.String(resp.ResponseContext.RequestId)
 	data.Id = to.String(publicIp.PublicIpId)
 	data.PublicIpId = to.String(publicIp.PublicIpId)
 	data.PublicIp = to.String(publicIp.PublicIp)

--- a/internal/services/oapi/resource_public_ip_link.go
+++ b/internal/services/oapi/resource_public_ip_link.go
@@ -20,6 +20,7 @@ import (
 	"github.com/outscale/osc-sdk-go/v3/pkg/osc"
 	"github.com/outscale/terraform-provider-outscale/internal/client"
 	"github.com/outscale/terraform-provider-outscale/internal/framework/fwhelpers"
+	"github.com/outscale/terraform-provider-outscale/internal/framework/fwhelpers/from"
 	"github.com/outscale/terraform-provider-outscale/internal/framework/fwhelpers/to"
 )
 
@@ -31,9 +32,7 @@ var (
 
 const (
 	publicIpLinkErrLink   = "Unable to link Public IP"
-	publicIpLinkErrRead   = "Unable to read Public IP Link"
 	publicIpLinkErrUnlink = "Unable to unlink Public IP"
-	publicIpLinkErrState  = "Unable to set Public IP Link state"
 )
 
 type publicIpLinkModel struct {
@@ -223,10 +222,12 @@ func (r *publicIpLinkResource) Create(ctx context.Context, req resource.CreateRe
 	} else {
 		data.Id = data.PublicIp
 	}
+	// The API response does not contain enough information to set the state directly, which would cause an error.
+	// The next read will fill the state
 
 	stateData, err := r.read(ctx, timeout, data)
 	if err != nil {
-		resp.Diagnostics.AddError(publicIpLinkErrState, err.Error())
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
@@ -248,7 +249,7 @@ func (r *publicIpLinkResource) Read(ctx context.Context, req resource.ReadReques
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(publicIpLinkErrRead, err.Error())
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
@@ -307,7 +308,7 @@ func (r *publicIpLinkResource) read(ctx context.Context, timeout time.Duration, 
 
 	tags, diag := flattenOAPIComputedTagsFW(ctx, publicIp.Tags)
 	if diag.HasError() {
-		return data, fmt.Errorf("%v", diag.Errors())
+		return data, from.Diag(diag)
 	}
 
 	data.Tags = tags

--- a/internal/services/oapi/resource_public_ip_test.go
+++ b/internal/services/oapi/resource_public_ip_test.go
@@ -1,6 +1,8 @@
 package oapi_test
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -32,6 +34,24 @@ func TestAccVM_PublicIP_Migration(t *testing.T) {
 	})
 }
 
+func TestAccOthers_PublicIP_CreateFailureKeepsState(t *testing.T) {
+	resourceName := "outscale_public_ip.pip"
+	invalidTagKey := strings.Repeat("a", 256)
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testacc.ProtoV6ProviderFactories(),
+		Steps: testacc.CreateFailureReplacementSteps(
+			resourceName,
+			testAccPublicIPConfigWithTag(invalidTagKey, "public_ip_test"),
+			testAccPublicIPConfigWithTag("Name", "public_ip_test_recovery"),
+			resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttrSet(resourceName, "public_ip_id"),
+				resource.TestCheckResourceAttr(resourceName, "tags.0.value", "public_ip_test_recovery"),
+			),
+		),
+	})
+}
+
 const testAccPublicIPConfig = `
 resource "outscale_public_ip" "pip" {
 	tags {
@@ -40,3 +60,14 @@ resource "outscale_public_ip" "pip" {
 	}
 }
 `
+
+func testAccPublicIPConfigWithTag(tagKey, tagValue string) string {
+	return fmt.Sprintf(`
+resource "outscale_public_ip" "pip" {
+	tags {
+		key = %q
+		value = %q
+	}
+}
+`, tagKey, tagValue)
+}

--- a/internal/services/oapi/resource_route.go
+++ b/internal/services/oapi/resource_route.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -29,6 +30,13 @@ var (
 	_ resource.ResourceWithImportState    = &resourceRoute{}
 	_ resource.ResourceWithModifyPlan     = &resourceRoute{}
 	_ resource.ResourceWithValidateConfig = &resourceRoute{}
+)
+
+const (
+	routeErrCreate = "Unable to create Route"
+	routeErrUpdate = "Unable to update Route"
+	routeErrDelete = "Unable to delete Route"
+	routeErrWait   = "Unable to wait for Route state"
 )
 
 type RouteCoreModel struct {
@@ -232,7 +240,7 @@ func (r *resourceRoute) Create(ctx context.Context, req resource.CreateRequest, 
 		return
 	}
 
-	createTimeout, diags := data.Timeouts.Create(ctx, CreateDefaultTimeout)
+	timeout, diags := data.Timeouts.Create(ctx, CreateDefaultTimeout)
 	if fwhelpers.CheckDiags(resp, diags) {
 		return
 	}
@@ -258,46 +266,46 @@ func (r *resourceRoute) Create(ctx context.Context, req resource.CreateRequest, 
 		createReq.NetPeeringId = data.NetPeeringId.ValueStringPointer()
 	}
 
-	createResp, err := r.Client.CreateRoute(ctx, createReq, options.WithRetryTimeout(createTimeout))
+	createResp, err := r.Client.CreateRoute(ctx, createReq, options.WithRetryTimeout(timeout))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to create Route.",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(routeErrCreate, err.Error())
 		return
 	}
 	rt := ptr.From(createResp.RouteTable)
 	data.RequestId = to.String(createResp.ResponseContext.RequestId)
 	data.Id = to.String(rt.RouteTableId + "_" + data.DestinationIpRange.ValueString())
 
-	if data.AwaitActiveState.ValueBool() {
-		stateConf := &retry.StateChangeConf{
-			Target:  []string{"active"},
-			Refresh: ResourceRouteStateRefreshFunc(ctx, r, "blackhole", rt.RouteTableId, data.DestinationIpRange.ValueString()),
-			Timeout: createTimeout,
-		}
-
-		if _, err = stateConf.WaitForStateContext(ctx); err != nil {
-			resp.Diagnostics.AddError(
-				fmt.Sprintf("Error waiting for Route (%s) to become active.",
-					data.Id.ValueString(),
-				),
-				err.Error(),
-			)
-			return
-		}
-	}
-
-	stateData, err := r.read(ctx, data)
+	stateData, err := r.flatten(data, rt)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to set Route state.",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
+		return
+	}
+	diags = resp.State.Set(ctx, &stateData)
+	if fwhelpers.CheckDiags(resp, diags) {
 		return
 	}
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &stateData)...)
+	if data.AwaitActiveState.ValueBool() {
+		stateConf := &retry.StateChangeConf{
+			Target:  []string{"active"},
+			Refresh: r.refreshFunc(ctx, "blackhole", rt.RouteTableId, data.DestinationIpRange.ValueString()),
+			Timeout: timeout,
+		}
+
+		routeTableAny, err := stateConf.WaitForStateContext(ctx)
+		if err != nil {
+			resp.Diagnostics.AddError(routeErrWait, err.Error())
+			return
+		}
+
+		stateData, err = r.flatten(data, routeTableAny.(osc.RouteTable))
+		if err != nil {
+			resp.Diagnostics.AddError(errSetTerraformState, err.Error())
+			return
+		}
+
+		resp.Diagnostics.Append(resp.State.Set(ctx, &stateData)...)
+	}
 }
 
 func getRouteFromRouteTable(routeTable osc.RouteTable, destinationIpRange string) (osc.Route, error) {
@@ -310,7 +318,7 @@ func getRouteFromRouteTable(routeTable osc.RouteTable, destinationIpRange string
 		"and destination CIDR block (%s)", routeTable.RouteTableId, destinationIpRange)
 }
 
-func ResourceRouteStateRefreshFunc(ctx context.Context, r *resourceRoute, failState string, routeTableId string, destinationIpRange string) retry.StateRefreshFunc {
+func (r *resourceRoute) refreshFunc(ctx context.Context, failState string, routeTableId string, destinationIpRange string) retry.StateRefreshFunc {
 	return func() (any, string, error) {
 		readReq := osc.ReadRouteTablesRequest{Filters: &osc.FiltersRouteTable{
 			RouteDestinationIpRanges: &[]string{destinationIpRange},
@@ -319,17 +327,22 @@ func ResourceRouteStateRefreshFunc(ctx context.Context, r *resourceRoute, failSt
 
 		resp, err := r.Client.ReadRouteTables(ctx, readReq, options.WithRetryTimeout(ReadDefaultTimeout))
 		if err != nil {
-			return resp, "error", err
+			return nil, "", err
 		}
-		route, err := getRouteFromRouteTable((ptr.From(resp.RouteTables))[0], destinationIpRange)
+		if len(ptr.From(resp.RouteTables)) == 0 {
+			return nil, "", ErrResourceEmpty
+		}
+		rt := (*resp.RouteTables)[0]
+
+		route, err := getRouteFromRouteTable(rt, destinationIpRange)
 		if err != nil {
-			return resp, "error", err
+			return nil, "", err
 		}
 		if route.State == failState {
-			return resp, failState, fmt.Errorf("failed to reach target state: route is in '%v' failing state", failState)
+			return nil, "", fmt.Errorf("failed to reach target state: route is in '%v' failing state", failState)
 		}
 
-		return resp, route.State, nil
+		return rt, route.State, nil
 	}
 }
 
@@ -341,16 +354,18 @@ func (r *resourceRoute) Read(ctx context.Context, req resource.ReadRequest, resp
 		return
 	}
 
-	data, err := r.read(ctx, data)
+	timeout, diags := data.Timeouts.Read(ctx, ReadDefaultTimeout)
+	if fwhelpers.CheckDiags(resp, diags) {
+		return
+	}
+
+	data, err := r.read(ctx, timeout, data)
 	if err != nil {
 		if errors.Is(err, ErrResourceEmpty) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(
-			"Unable to set Route API response values.",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -364,6 +379,11 @@ func (r *resourceRoute) Update(ctx context.Context, req resource.UpdateRequest, 
 	}
 	resp.Diagnostics.Append(req.State.Get(ctx, &stateData)...)
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	timeout, diags := planData.Timeouts.Update(ctx, UpdateDefaultTimeout)
+	if fwhelpers.CheckDiags(resp, diags) {
 		return
 	}
 
@@ -398,18 +418,15 @@ func (r *resourceRoute) Update(ctx context.Context, req resource.UpdateRequest, 
 	}
 
 	if updateCall {
-		updateTimeout, diags := planData.Timeouts.Update(ctx, UpdateDefaultTimeout)
+		timeout, diags := planData.Timeouts.Update(ctx, UpdateDefaultTimeout)
 		resp.Diagnostics.Append(diags...)
 		if resp.Diagnostics.HasError() {
 			return
 		}
 
-		createResp, err := r.Client.UpdateRoute(ctx, updateReq, options.WithRetryTimeout(updateTimeout))
+		createResp, err := r.Client.UpdateRoute(ctx, updateReq, options.WithRetryTimeout(timeout))
 		if err != nil {
-			resp.Diagnostics.AddError(
-				"Unable to update Route resource.",
-				err.Error(),
-			)
+			resp.Diagnostics.AddError(routeErrUpdate, err.Error())
 			return
 		}
 		stateData.RequestId = to.String(createResp.ResponseContext.RequestId)
@@ -417,29 +434,21 @@ func (r *resourceRoute) Update(ctx context.Context, req resource.UpdateRequest, 
 		if stateData.AwaitActiveState.ValueBool() {
 			stateConf := &retry.StateChangeConf{
 				Target:  []string{"active"},
-				Timeout: updateTimeout,
-				Refresh: ResourceRouteStateRefreshFunc(ctx, r, "blackhole", stateData.RouteTableId.ValueString(), stateData.DestinationIpRange.ValueString()),
+				Timeout: timeout,
+				Refresh: r.refreshFunc(ctx, "blackhole", stateData.RouteTableId.ValueString(), stateData.DestinationIpRange.ValueString()),
 			}
 
 			if _, err = stateConf.WaitForStateContext(ctx); err != nil {
-				resp.Diagnostics.AddError(
-					fmt.Sprintf("Error waiting for Route (%s) to become active.",
-						stateData.Id.ValueString(),
-					),
-					err.Error(),
-				)
+				resp.Diagnostics.AddError(routeErrWait, err.Error())
 				return
 			}
 		}
 	}
 
 	stateData.Timeouts = planData.Timeouts
-	data, err := r.read(ctx, stateData)
+	data, err := r.read(ctx, timeout, stateData)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to set Route state.",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
@@ -454,7 +463,7 @@ func (r *resourceRoute) Delete(ctx context.Context, req resource.DeleteRequest, 
 		return
 	}
 
-	deleteTimeout, diags := data.Timeouts.Delete(ctx, DeleteDefaultTimeout)
+	timeout, diags := data.Timeouts.Delete(ctx, DeleteDefaultTimeout)
 	if fwhelpers.CheckDiags(resp, diags) {
 		return
 	}
@@ -464,27 +473,19 @@ func (r *resourceRoute) Delete(ctx context.Context, req resource.DeleteRequest, 
 		RouteTableId:       data.RouteTableId.ValueString(),
 	}
 
-	_, err := r.Client.DeleteRoute(ctx, delReq, options.WithRetryTimeout(deleteTimeout))
+	_, err := r.Client.DeleteRoute(ctx, delReq, options.WithRetryTimeout(timeout))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to Delete Route.",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(routeErrDelete, err.Error())
 	}
 }
 
-func (r *resourceRoute) read(ctx context.Context, data RouteModel) (RouteModel, error) {
+func (r *resourceRoute) read(ctx context.Context, timeout time.Duration, data RouteModel) (RouteModel, error) {
 	readReq := osc.ReadRouteTablesRequest{Filters: &osc.FiltersRouteTable{
 		RouteDestinationIpRanges: &[]string{data.DestinationIpRange.ValueString()},
 		RouteTableIds:            &[]string{data.RouteTableId.ValueString()},
 	}}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, ReadDefaultTimeout)
-	if diags.HasError() {
-		return data, fmt.Errorf("unable to parse 'route' read timeout value: %v", diags.Errors())
-	}
-
-	readResp, err := r.Client.ReadRouteTables(ctx, readReq, options.WithRetryTimeout(readTimeout))
+	readResp, err := r.Client.ReadRouteTables(ctx, readReq, options.WithRetryTimeout(timeout))
 	if err != nil {
 		return data, err
 	}
@@ -494,6 +495,11 @@ func (r *resourceRoute) read(ctx context.Context, data RouteModel) (RouteModel, 
 	data.RequestId = to.String(readResp.ResponseContext.RequestId)
 
 	routeTable := (ptr.From(readResp.RouteTables))[0]
+
+	return r.flatten(data, routeTable)
+}
+
+func (r *resourceRoute) flatten(data RouteModel, routeTable osc.RouteTable) (RouteModel, error) {
 	route, err := getRouteFromRouteTable(routeTable, data.DestinationIpRange.ValueString())
 	if err != nil {
 		return data, ErrResourceEmpty

--- a/internal/services/oapi/resource_route_table.go
+++ b/internal/services/oapi/resource_route_table.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -17,6 +18,7 @@ import (
 	"github.com/outscale/osc-sdk-go/v3/pkg/osc"
 	"github.com/outscale/terraform-provider-outscale/internal/client"
 	"github.com/outscale/terraform-provider-outscale/internal/framework/fwhelpers"
+	"github.com/outscale/terraform-provider-outscale/internal/framework/fwhelpers/from"
 	"github.com/outscale/terraform-provider-outscale/internal/framework/fwhelpers/to"
 	"github.com/samber/lo"
 )
@@ -26,6 +28,11 @@ var (
 	_ resource.ResourceWithConfigure   = &resourceRouteTable{}
 	_ resource.ResourceWithImportState = &resourceRouteTable{}
 	_ resource.ResourceWithModifyPlan  = &resourceRouteTable{}
+)
+
+const (
+	routeTableErrCreate = "Unable to create Route Table"
+	routeTableErrDelete = "Unable to delete Route Table"
 )
 
 type RouteTableModel struct {
@@ -219,7 +226,7 @@ func (r *resourceRouteTable) Create(ctx context.Context, req resource.CreateRequ
 		return
 	}
 
-	createTimeout, diags := data.Timeouts.Create(ctx, CreateDefaultTimeout)
+	timeout, diags := data.Timeouts.Create(ctx, CreateDefaultTimeout)
 	if fwhelpers.CheckDiags(resp, diags) {
 		return
 	}
@@ -228,33 +235,37 @@ func (r *resourceRouteTable) Create(ctx context.Context, req resource.CreateRequ
 		NetId: data.NetId.ValueString(),
 	}
 
-	createResp, err := r.Client.CreateRouteTable(ctx, createReq, options.WithRetryTimeout(createTimeout))
+	createResp, err := r.Client.CreateRouteTable(ctx, createReq, options.WithRetryTimeout(timeout))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to create Route Table resource.",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(routeTableErrCreate, err.Error())
 		return
 	}
 	data.RequestId = to.String(createResp.ResponseContext.RequestId)
 	routeTable := ptr.From(createResp.RouteTable)
+	data.RouteTableId = to.String(routeTable.RouteTableId)
+	data.Id = to.String(routeTable.RouteTableId)
 
-	diag := createOAPITagsFW(ctx, r.Client, createTimeout, data.Tags, routeTable.RouteTableId)
+	stateData, err := r.flatten(ctx, data, routeTable)
+	if err != nil {
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
+		return
+	}
+	diags = resp.State.Set(ctx, &stateData)
+	if fwhelpers.CheckDiags(resp, diags) {
+		return
+	}
+
+	diag := createOAPITagsFW(ctx, r.Client, timeout, data.Tags, routeTable.RouteTableId)
 	if fwhelpers.CheckDiags(resp, diag) {
 		return
 	}
 
-	data.RouteTableId = to.String(routeTable.RouteTableId)
-	data.Id = to.String(routeTable.RouteTableId)
-	data, err = r.read(ctx, data)
+	stateData, err = r.read(ctx, timeout, data)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to set Route Table state",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateData)...)
 }
 
 func (r *resourceRouteTable) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -265,16 +276,18 @@ func (r *resourceRouteTable) Read(ctx context.Context, req resource.ReadRequest,
 		return
 	}
 
-	data, err := r.read(ctx, data)
+	timeout, diags := data.Timeouts.Read(ctx, ReadDefaultTimeout)
+	if fwhelpers.CheckDiags(resp, diags) {
+		return
+	}
+
+	data, err := r.read(ctx, timeout, data)
 	if err != nil {
 		if errors.Is(err, ErrResourceEmpty) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(
-			"Unable to set Route Table API response values.",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -299,12 +312,9 @@ func (r *resourceRouteTable) Update(ctx context.Context, req resource.UpdateRequ
 	}
 
 	stateData.Timeouts = planData.Timeouts
-	data, err := r.read(ctx, stateData)
+	data, err := r.read(ctx, timeout, stateData)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to set Route Table state.",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
@@ -319,7 +329,7 @@ func (r *resourceRouteTable) Delete(ctx context.Context, req resource.DeleteRequ
 		return
 	}
 
-	deleteTimeout, diags := data.Timeouts.Delete(ctx, DeleteDefaultTimeout)
+	timeout, diags := data.Timeouts.Delete(ctx, DeleteDefaultTimeout)
 	if fwhelpers.CheckDiags(resp, diags) {
 		return
 	}
@@ -328,16 +338,13 @@ func (r *resourceRouteTable) Delete(ctx context.Context, req resource.DeleteRequ
 		RouteTableId: data.RouteTableId.ValueString(),
 	}
 
-	_, err := r.Client.DeleteRouteTable(ctx, delReq, options.WithRetryTimeout(deleteTimeout))
+	_, err := r.Client.DeleteRouteTable(ctx, delReq, options.WithRetryTimeout(timeout))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to Delete Route Table.",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(routeTableErrDelete, err.Error())
 	}
 }
 
-func (r *resourceRouteTable) read(ctx context.Context, data RouteTableModel) (RouteTableModel, error) {
+func (r *resourceRouteTable) read(ctx context.Context, timeout time.Duration, data RouteTableModel) (RouteTableModel, error) {
 	routeTableFilters := osc.FiltersRouteTable{
 		RouteTableIds: &[]string{data.RouteTableId.ValueString()},
 	}
@@ -345,12 +352,7 @@ func (r *resourceRouteTable) read(ctx context.Context, data RouteTableModel) (Ro
 		Filters: &routeTableFilters,
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, ReadDefaultTimeout)
-	if diags.HasError() {
-		return data, fmt.Errorf("unable to parse 'route table' read timeout value: %v", diags.Errors())
-	}
-
-	readResp, err := r.Client.ReadRouteTables(ctx, readReq, options.WithRetryTimeout(readTimeout))
+	readResp, err := r.Client.ReadRouteTables(ctx, readReq, options.WithRetryTimeout(timeout))
 	if err != nil {
 		return data, err
 	}
@@ -360,23 +362,28 @@ func (r *resourceRouteTable) read(ctx context.Context, data RouteTableModel) (Ro
 	data.RequestId = to.String(readResp.ResponseContext.RequestId)
 
 	routeTable := (*readResp.RouteTables)[0]
+
+	return r.flatten(ctx, data, routeTable)
+}
+
+func (r *resourceRouteTable) flatten(ctx context.Context, data RouteTableModel, routeTable osc.RouteTable) (RouteTableModel, error) {
 	tags, diag := flattenOAPITagsFW(ctx, routeTable.Tags)
 	if diag.HasError() {
-		return data, fmt.Errorf("unable to flatten tags: %v", diags.Errors())
+		return data, from.Diag(diag)
 	}
 	data.Tags = tags
 
 	linkRouteTables, diags := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: linkRouteTableAttrTypes}, LinkRouteTablesToModel(routeTable.LinkRouteTables))
 	if diags.HasError() {
-		return data, fmt.Errorf("unable to convert link route tables to the schema set: %v", diags.Errors())
+		return data, from.Diag(diags)
 	}
 	routePropagatingVirtualGateways, diags := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: routePropagatingVirtualGatewayAttrTypes}, RoutePropagatingVirtualGatewaysToModel(routeTable.RoutePropagatingVirtualGateways))
 	if diags.HasError() {
-		return data, fmt.Errorf("unable to convert route propagating virtual gateways to the schema set: %v", diags.Errors())
+		return data, from.Diag(diags)
 	}
 	routes, diags := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: routeAttrTypes}, RoutesToModel(routeTable.Routes))
 	if diags.HasError() {
-		return data, fmt.Errorf("unable to convert routes to the schema set: %v", diags.Errors())
+		return data, from.Diag(diags)
 	}
 
 	data.LinkRouteTables = linkRouteTables

--- a/internal/services/oapi/resource_route_table_link.go
+++ b/internal/services/oapi/resource_route_table_link.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -27,6 +28,11 @@ var (
 	_ resource.ResourceWithConfigure   = &resourceRouteTableLink{}
 	_ resource.ResourceWithImportState = &resourceRouteTableLink{}
 	_ resource.ResourceWithModifyPlan  = &resourceRouteTableLink{}
+)
+
+const (
+	routeTableLinkErrCreate = "Unable to create Route Table Link"
+	routeTableLinkErrDelete = "Unable to delete Route Table Link"
 )
 
 type RouteTableLinkCoreModel struct {
@@ -162,7 +168,7 @@ func (r *resourceRouteTableLink) Create(ctx context.Context, req resource.Create
 		return
 	}
 
-	createTimeout, diags := data.Timeouts.Create(ctx, CreateDefaultTimeout)
+	timeout, diags := data.Timeouts.Create(ctx, CreateDefaultTimeout)
 	if fwhelpers.CheckDiags(resp, diags) {
 		return
 	}
@@ -172,25 +178,21 @@ func (r *resourceRouteTableLink) Create(ctx context.Context, req resource.Create
 		SubnetId:     data.SubnetId.ValueString(),
 	}
 
-	createResp, err := r.Client.LinkRouteTable(ctx, createReq, options.WithRetryTimeout(createTimeout))
+	createResp, err := r.Client.LinkRouteTable(ctx, createReq, options.WithRetryTimeout(timeout))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to create Route Table Link.",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(routeTableLinkErrCreate, err.Error())
 		return
 	}
 	linkRouteTableId := ptr.From(createResp.LinkRouteTableId)
 	data.RequestId = to.String(createResp.ResponseContext.RequestId)
 	data.LinkRouteTableId = to.String(linkRouteTableId)
 	data.Id = to.String(linkRouteTableId)
+	// The API response does not contain enough information to set the state directly, which would cause an error.
+	// The next read will fill the state
 
-	data, err = r.read(ctx, data)
+	data, err = r.read(ctx, timeout, data)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to set Route Table Link state",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -204,16 +206,18 @@ func (r *resourceRouteTableLink) Read(ctx context.Context, req resource.ReadRequ
 		return
 	}
 
-	data, err := r.read(ctx, data)
+	timeout, diags := data.Timeouts.Read(ctx, ReadDefaultTimeout)
+	if fwhelpers.CheckDiags(resp, diags) {
+		return
+	}
+
+	data, err := r.read(ctx, timeout, data)
 	if err != nil {
 		if errors.Is(err, ErrResourceEmpty) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(
-			"Unable to set Route Table Link API response values.",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -230,7 +234,7 @@ func (r *resourceRouteTableLink) Delete(ctx context.Context, req resource.Delete
 		return
 	}
 
-	deleteTimeout, diags := data.Timeouts.Delete(ctx, DeleteDefaultTimeout)
+	timeout, diags := data.Timeouts.Delete(ctx, DeleteDefaultTimeout)
 	if fwhelpers.CheckDiags(resp, diags) {
 		return
 	}
@@ -239,16 +243,13 @@ func (r *resourceRouteTableLink) Delete(ctx context.Context, req resource.Delete
 		LinkRouteTableId: data.LinkRouteTableId.ValueString(),
 	}
 
-	_, err := r.Client.UnlinkRouteTable(ctx, delReq, options.WithRetryTimeout(deleteTimeout))
+	_, err := r.Client.UnlinkRouteTable(ctx, delReq, options.WithRetryTimeout(timeout))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to delete Route Table Link.",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(routeTableLinkErrDelete, err.Error())
 	}
 }
 
-func (r *resourceRouteTableLink) read(ctx context.Context, data RouteTableLinkModel) (RouteTableLinkModel, error) {
+func (r *resourceRouteTableLink) read(ctx context.Context, timeout time.Duration, data RouteTableLinkModel) (RouteTableLinkModel, error) {
 	routeTableLinkFilters := osc.FiltersRouteTable{
 		RouteTableIds: &[]string{data.RouteTableId.ValueString()},
 	}
@@ -256,12 +257,7 @@ func (r *resourceRouteTableLink) read(ctx context.Context, data RouteTableLinkMo
 		Filters: &routeTableLinkFilters,
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, ReadDefaultTimeout)
-	if diags.HasError() {
-		return data, fmt.Errorf("unable to parse 'route table link' read timeout value: %v", diags.Errors())
-	}
-
-	readResp, err := r.Client.ReadRouteTables(ctx, readReq, options.WithRetryTimeout(readTimeout))
+	readResp, err := r.Client.ReadRouteTables(ctx, readReq, options.WithRetryTimeout(timeout))
 	if err != nil {
 		return data, err
 	}

--- a/internal/services/oapi/resource_route_table_test.go
+++ b/internal/services/oapi/resource_route_table_test.go
@@ -3,6 +3,7 @@ package oapi_test
 import (
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -96,6 +97,31 @@ func TestAccNet_RouteTable_importBasic(t *testing.T) {
 			},
 			testacc.ImportStep(resourceName, testacc.DefaultIgnores()...),
 		},
+	})
+}
+
+func TestAccNet_RouteTable_CreateFailureKeepsState(t *testing.T) {
+	resourceName := "outscale_route_table.rtbTest"
+	invalidTagKey := strings.Repeat("a", 256)
+	tag := func(key string) string {
+		return fmt.Sprintf(`
+		tags {
+			key = %q
+			value = "Terraform-RT-3"
+		}`, key)
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testacc.ProtoV6ProviderFactories(),
+		Steps: testacc.CreateFailureReplacementSteps(
+			resourceName,
+			testAccOAPIRouteTableConfigTags(tag(invalidTagKey)),
+			testAccOAPIRouteTableConfigTags(tag("name")),
+			resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttrSet(resourceName, "route_table_id"),
+				resource.TestCheckResourceAttr(resourceName, "tags.0.value", "Terraform-RT-3"),
+			),
+		),
 	})
 }
 

--- a/internal/services/oapi/resource_route_test.go
+++ b/internal/services/oapi/resource_route_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/outscale/terraform-provider-outscale/internal/services/oapi/oapihelpers"
 	"github.com/outscale/terraform-provider-outscale/internal/testacc"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -176,6 +177,25 @@ func TestAccNet_Route_Migration(t *testing.T) {
 	})
 }
 
+func TestAccNet_Route_CreateFailureKeepsState(t *testing.T) {
+	resourceName := "outscale_route.blackhole"
+	accountID := oapihelpers.GetAccepterOwnerId()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testacc.ProtoV6ProviderFactories(),
+		Steps: testacc.CreateFailureReplacementSteps(
+			resourceName,
+			testAccOutscaleRouteBlackholeConfig(accountID, false),
+			testAccOutscaleRouteBlackholeConfig(accountID, true),
+			resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttrSet(resourceName, "id"),
+				resource.TestCheckResourceAttrSet(resourceName, "net_peering_id"),
+				resource.TestCheckResourceAttr(resourceName, "state", "active"),
+			),
+		),
+	})
+}
+
 var testAccOutscaleRouteNoopChange = `
 	resource "outscale_net" "test" {
 		ip_range = "10.0.0.0/24"
@@ -271,6 +291,46 @@ var testAccOutscaleRouteWithNatService = `
 		route_table_id       = outscale_route_table.outscale_route_table.route_table_id
 	}
 `
+
+func testAccOutscaleRouteBlackholeConfig(accountID string, acceptPeering bool) string {
+	acceptation := ""
+	if acceptPeering {
+		acceptation = `
+	resource "outscale_net_peering_acceptation" "accept" {
+		net_peering_id = outscale_net_peering.peer.id
+	}
+`
+	}
+
+	return fmt.Sprintf(`
+	resource "outscale_net" "test" {
+		ip_range = "10.10.0.0/24"
+	}
+
+	resource "outscale_net" "peer" {
+		ip_range = "10.20.0.0/24"
+	}
+
+	resource "outscale_route_table" "test" {
+		net_id = outscale_net.test.net_id
+	}
+
+	resource "outscale_net_peering" "peer" {
+		source_net_id     = outscale_net.test.net_id
+		accepter_net_id   = outscale_net.peer.net_id
+		accepter_owner_id = %q
+	}
+
+	%s
+
+	resource "outscale_route" "blackhole" {
+		net_peering_id       = outscale_net_peering.peer.net_peering_id
+		destination_ip_range = "0.0.0.0/0"
+		route_table_id       = outscale_route_table.test.route_table_id
+		await_active_state   = true
+	}
+	`, accountID, acceptation)
+}
 
 func computeConfigTestChangeTarget(targets []string) string {
 	var extra_configs []string

--- a/internal/services/oapi/resource_security_group.go
+++ b/internal/services/oapi/resource_security_group.go
@@ -27,6 +27,7 @@ import (
 	"github.com/outscale/osc-sdk-go/v3/pkg/osc"
 	"github.com/outscale/terraform-provider-outscale/internal/client"
 	"github.com/outscale/terraform-provider-outscale/internal/framework/fwhelpers"
+	"github.com/outscale/terraform-provider-outscale/internal/framework/fwhelpers/from"
 	"github.com/outscale/terraform-provider-outscale/internal/framework/fwhelpers/to"
 	"github.com/outscale/terraform-provider-outscale/internal/framework/modifyplans"
 	"github.com/outscale/terraform-provider-outscale/internal/services/oapi/oapihelpers"
@@ -38,6 +39,16 @@ var (
 	_ resource.ResourceWithConfigure   = &resourceSecurityGroup{}
 	_ resource.ResourceWithImportState = &resourceSecurityGroup{}
 	_ resource.ResourceWithModifyPlan  = &resourceSecurityGroup{}
+)
+
+const (
+	securityGroupErrCreate      = "Unable to create Security Group"
+	securityGroupErrDelete      = "Unable to delete Security Group"
+	securityGroupErrRules       = "Unable to empty Security Group rules"
+	securityGroupErrDeleteRetry = "Unable to delete Security Group after unlinking resources"
+	securityGroupErrReadVMs     = "Unable to read VMs linked to Security Group"
+	securityGroupErrReadNICs    = "Unable to read NICs linked to Security Group"
+	securityGroupErrReadLBUs    = "Unable to read Load Balancers linked to Security Group"
 )
 
 type SecurityGroupModel struct {
@@ -292,13 +303,10 @@ func (r *resourceSecurityGroup) Create(ctx context.Context, req resource.CreateR
 	var data SecurityGroupModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
 
-	createTimeout, diag := data.Timeouts.Create(ctx, CreateDefaultTimeout)
+	timeout, diag := data.Timeouts.Create(ctx, CreateDefaultTimeout)
 	if fwhelpers.CheckDiags(resp, diag) {
 		return
 	}
-
-	ctx, cancel := context.WithTimeout(ctx, createTimeout)
-	defer cancel()
 
 	if !fwhelpers.IsSet(data.SecurityGroupName) {
 		data.SecurityGroupName = to.String(id.UniqueId())
@@ -313,18 +321,25 @@ func (r *resourceSecurityGroup) Create(ctx context.Context, req resource.CreateR
 		createReq.NetId = data.NetId.ValueStringPointer()
 	}
 
-	createResp, err := r.Client.CreateSecurityGroup(ctx, createReq, options.WithRetryTimeout(createTimeout))
+	createResp, err := r.Client.CreateSecurityGroup(ctx, createReq, options.WithRetryTimeout(timeout))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to create Security Group.",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(securityGroupErrCreate, err.Error())
 		return
 	}
 	sg := ptr.From(createResp.SecurityGroup)
 	data.RequestId = to.String(createResp.ResponseContext.RequestId)
 	data.Id = to.String(sg.SecurityGroupId)
 	data.SecurityGroupId = to.String(sg.SecurityGroupId)
+
+	stateData, err := r.flatten(ctx, data, sg)
+	if err != nil {
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
+		return
+	}
+	diag = resp.State.Set(ctx, &stateData)
+	if fwhelpers.CheckDiags(resp, diag) {
+		return
+	}
 
 	if data.RemoveDefaultOutboundRule.ValueBool() {
 		ipRange := "0.0.0.0/0"
@@ -336,27 +351,21 @@ func (r *resourceSecurityGroup) Create(ctx context.Context, req resource.CreateR
 			IpProtocol:      &ipProtocol,
 		}
 
-		_, err := r.Client.DeleteSecurityGroupRule(ctx, emptySGReq, options.WithRetryTimeout(createTimeout))
+		_, err := r.Client.DeleteSecurityGroupRule(ctx, emptySGReq, options.WithRetryTimeout(timeout))
 		if err != nil {
-			resp.Diagnostics.AddError(
-				"Unable to empty the Security Group rules.",
-				err.Error(),
-			)
+			resp.Diagnostics.AddError(securityGroupErrRules, err.Error())
 			return
 		}
 	}
 
-	diag = createOAPITagsFW(ctx, r.Client, createTimeout, data.Tags, sg.SecurityGroupId)
+	diag = createOAPITagsFW(ctx, r.Client, timeout, data.Tags, sg.SecurityGroupId)
 	if fwhelpers.CheckDiags(resp, diag) {
 		return
 	}
 
-	stateData, err := setSecurityGroupState(ctx, r, data)
+	stateData, err = r.read(ctx, timeout, data)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to set Security Group state.",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
@@ -370,16 +379,18 @@ func (r *resourceSecurityGroup) Read(ctx context.Context, req resource.ReadReque
 		return
 	}
 
-	data, err := setSecurityGroupState(ctx, r, data)
+	timeout, diag := data.Timeouts.Read(ctx, ReadDefaultTimeout)
+	if fwhelpers.CheckDiags(resp, diag) {
+		return
+	}
+
+	data, err := r.read(ctx, timeout, data)
 	if err != nil {
 		if errors.Is(err, ErrResourceEmpty) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(
-			"Unable to set Security Group API response values.",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
@@ -405,12 +416,9 @@ func (r *resourceSecurityGroup) Update(ctx context.Context, req resource.UpdateR
 	}
 
 	stateData.Timeouts = planData.Timeouts
-	data, err := setSecurityGroupState(ctx, r, stateData)
+	data, err := r.read(ctx, timeout, stateData)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to set Security Group state.",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
@@ -421,13 +429,10 @@ func (r *resourceSecurityGroup) Delete(ctx context.Context, req resource.DeleteR
 	var data SecurityGroupModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
 
-	deleteTimeout, diag := data.Timeouts.Delete(ctx, DeleteDefaultTimeout)
+	timeout, diag := data.Timeouts.Delete(ctx, DeleteDefaultTimeout)
 	if fwhelpers.CheckDiags(resp, diag) {
 		return
 	}
-
-	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
-	defer cancel()
 
 	sgId := data.Id.ValueString()
 	delReq := osc.DeleteSecurityGroupRequest{
@@ -435,22 +440,19 @@ func (r *resourceSecurityGroup) Delete(ctx context.Context, req resource.DeleteR
 	}
 
 	sgLinked := false
-	_, err := r.Client.DeleteSecurityGroup(ctx, delReq, options.WithRetryTimeout(deleteTimeout))
+	_, err := r.Client.DeleteSecurityGroup(ctx, delReq, options.WithRetryTimeout(timeout))
 	if err != nil {
 		oscErr := oapihelpers.GetError(err)
 		if oscErr.Code == "9085" {
 			sgLinked = true
 		} else {
-			resp.Diagnostics.AddError(
-				"Unable to delete Security Group.",
-				err.Error(),
-			)
+			resp.Diagnostics.AddError(securityGroupErrDelete, err.Error())
 			return
 		}
 	}
 
 	if sgLinked {
-		diag = r.unlink(ctx, deleteTimeout, data)
+		diag = r.unlink(ctx, timeout, data)
 		if diag.HasError() {
 			resp.Diagnostics.Append(diag...)
 			return
@@ -458,13 +460,10 @@ func (r *resourceSecurityGroup) Delete(ctx context.Context, req resource.DeleteR
 
 		// // Retry on 409 as API can take time to return a security group as not in use anymore
 		_, err := oapihelpers.RetryOnCodes(ctx, []string{"9085"}, func() (resp any, err error) {
-			return r.Client.DeleteSecurityGroup(ctx, delReq, options.WithRetryTimeout(deleteTimeout))
-		}, deleteTimeout)
+			return r.Client.DeleteSecurityGroup(ctx, delReq, options.WithRetryTimeout(timeout))
+		}, timeout)
 		if err != nil {
-			resp.Diagnostics.AddError(
-				"Unable to delete Security Group after unlinking from resources.",
-				err.Error(),
-			)
+			resp.Diagnostics.AddError(securityGroupErrDeleteRetry, err.Error())
 			return
 		}
 	}
@@ -482,10 +481,7 @@ func (r *resourceSecurityGroup) getLinkedResources(ctx context.Context, to time.
 
 	vms, err := r.Client.ReadVms(ctx, readVmReq, options.WithRetryTimeout(to))
 	if err != nil {
-		diags.AddError(
-			"Unable to find VMs linked to Security Group.",
-			err.Error(),
-		)
+		diags.AddError(securityGroupErrReadVMs, err.Error())
 		return nil, nil, nil, diags
 	}
 
@@ -498,20 +494,14 @@ func (r *resourceSecurityGroup) getLinkedResources(ctx context.Context, to time.
 
 	nics, err := r.Client.ReadNics(ctx, readNicsReq, options.WithRetryTimeout(to))
 	if err != nil {
-		diags.AddError(
-			"Unable to find NICs linked to Security Group.",
-			err.Error(),
-		)
+		diags.AddError(securityGroupErrReadNICs, err.Error())
 		return nil, nil, nil, diags
 	}
 
 	// Get LBUs linked to Security Group
 	lbus, err := r.Client.ReadLoadBalancers(ctx, osc.ReadLoadBalancersRequest{}, options.WithRetryTimeout(to))
 	if err != nil {
-		diags.AddError(
-			"Unable to find Load Balancers linked to Security Group.",
-			err.Error(),
-		)
+		diags.AddError(securityGroupErrReadLBUs, err.Error())
 		return nil, nil, nil, diags
 	}
 
@@ -668,12 +658,8 @@ func (r *resourceSecurityGroup) unlink(ctx context.Context, to time.Duration, da
 	return
 }
 
-func setSecurityGroupState(ctx context.Context, r *resourceSecurityGroup, data SecurityGroupModel) (SecurityGroupModel, error) {
-	readTimeout, diag := data.Timeouts.Read(ctx, ReadDefaultTimeout)
-	if diag.HasError() {
-		return data, fmt.Errorf("unable to parse 'security_group' read timeout value: %v", diag.Errors())
-	}
-	ctxWithTimeout, cancel := context.WithTimeout(ctx, readTimeout)
+func (r *resourceSecurityGroup) read(ctx context.Context, timeout time.Duration, data SecurityGroupModel) (SecurityGroupModel, error) {
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	securityGroup, err := r.Batcher.Read(ctxWithTimeout, data.Id.ValueString())
@@ -684,27 +670,31 @@ func setSecurityGroupState(ctx context.Context, r *resourceSecurityGroup, data S
 		return data, err
 	}
 
+	return r.flatten(ctx, data, *securityGroup)
+}
+
+func (r *resourceSecurityGroup) flatten(ctx context.Context, data SecurityGroupModel, securityGroup osc.SecurityGroup) (SecurityGroupModel, error) {
 	tags, diags := flattenOAPITagsFW(ctx, securityGroup.Tags)
 	if diags.HasError() {
-		return data, fmt.Errorf("unable to flatten tags: %v", diags.Errors())
+		return data, from.Diag(diags)
 	}
 	data.Tags = tags
 
 	inboundRulesModels, diag := flattenSecurityGroupRules(ctx, securityGroup.InboundRules)
 	if diag.HasError() {
-		return data, fmt.Errorf("unable to convert inbound rules to the model: %v", diag.Errors())
+		return data, from.Diag(diag)
 	}
 	inboundRules, diag := types.ListValueFrom(ctx, securityGroupRulesModelAttrTypes, inboundRulesModels)
 	if diag.HasError() {
-		return data, fmt.Errorf("unable to convert inbound rules to the schema list: %v", diag.Errors())
+		return data, from.Diag(diag)
 	}
 	outboundRulesModels, diag := flattenSecurityGroupRules(ctx, securityGroup.OutboundRules)
 	if diag.HasError() {
-		return data, fmt.Errorf("unable to convert outbound rules to the model: %v", diag.Errors())
+		return data, from.Diag(diag)
 	}
 	outboundRules, diag := types.ListValueFrom(ctx, securityGroupRulesModelAttrTypes, outboundRulesModels)
 	if diag.HasError() {
-		return data, fmt.Errorf("unable to convert outbound rules to the schema list: %v", diag.Errors())
+		return data, from.Diag(diag)
 	}
 
 	data.AccountId = to.String(securityGroup.AccountId)

--- a/internal/services/oapi/resource_security_group_rule.go
+++ b/internal/services/oapi/resource_security_group_rule.go
@@ -44,6 +44,11 @@ var (
 	_ resource.ResourceWithValidateConfig = &resourceRoute{}
 )
 
+const (
+	securityGroupRuleErrCreate = "Unable to create Security Group Rule"
+	securityGroupRuleErrDelete = "Unable to delete Security Group Rule"
+)
+
 type SecurityGroupRuleModel struct {
 	Flow                         types.String   `tfsdk:"flow"`
 	FromPortRange                types.Int32    `tfsdk:"from_port_range"`
@@ -149,8 +154,18 @@ func (r *resourceSecurityGroupRule) ImportState(ctx context.Context, req resourc
 		filters.OutboundRuleIpRanges = &[]string{ipRange}
 	}
 
+	var timeouts timeouts.Value
+	diag := resp.State.GetAttribute(ctx, path.Root("timeouts"), &timeouts)
+	if fwhelpers.CheckDiags(resp, diag) {
+		return
+	}
+	timeout, diag := timeouts.Read(ctx, ReadDefaultTimeout)
+	if fwhelpers.CheckDiags(resp, diag) {
+		return
+	}
+
 	var data SecurityGroupRuleModel
-	readResp, err := r.readSecurityGroupsWithFilters(ctx, data, filters)
+	readResp, err := r.readSecurityGroupsWithFilters(ctx, timeout, data, filters)
 	if err != nil || readResp.SecurityGroups == nil || len(*readResp.SecurityGroups) != 1 {
 		resp.Diagnostics.AddError(
 			"Unable to find the Security Group Rule with the requested attributes",
@@ -160,11 +175,6 @@ func (r *resourceSecurityGroupRule) ImportState(ctx context.Context, req resourc
 	}
 	securityGroup := (*readResp.SecurityGroups)[0]
 
-	var timeouts timeouts.Value
-	diag := resp.State.GetAttribute(ctx, path.Root("timeouts"), &timeouts)
-	if fwhelpers.CheckDiags(resp, diag) {
-		return
-	}
 	data.Timeouts = timeouts
 	data.RequestId = to.String(readResp.ResponseContext.RequestId)
 	data.Id = to.String(securityGroup.SecurityGroupId)
@@ -473,13 +483,10 @@ func (r *resourceSecurityGroupRule) Create(ctx context.Context, req resource.Cre
 	var data SecurityGroupRuleModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
 
-	createTimeout, diag := data.Timeouts.Create(ctx, CreateDefaultTimeout)
+	timeout, diag := data.Timeouts.Create(ctx, CreateDefaultTimeout)
 	if fwhelpers.CheckDiags(resp, diag) {
 		return
 	}
-
-	ctx, cancel := context.WithTimeout(ctx, createTimeout)
-	defer cancel()
 
 	createReq := osc.CreateSecurityGroupRuleRequest{
 		Flow:            data.Flow.ValueString(),
@@ -519,33 +526,23 @@ func (r *resourceSecurityGroupRule) Create(ctx context.Context, req resource.Cre
 		return
 	}
 
-	createResp, err := r.Client.CreateSecurityGroupRule(ctx, createReq, options.WithRetryTimeout(createTimeout))
+	createResp, err := r.Client.CreateSecurityGroupRule(ctx, createReq, options.WithRetryTimeout(timeout))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to create Security Group Rule.",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(securityGroupRuleErrCreate, err.Error())
 		return
 	}
 	sg := ptr.From(createResp.SecurityGroup)
 	data.RequestId = to.String(createResp.ResponseContext.RequestId)
 	data.Id = to.String(sg.SecurityGroupId)
 
-	stateData, err := r.read(ctx, data, createTimeout)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to set Security Group Rule state.",
-			err.Error(),
-		)
-		return
-	}
+	stateData := r.flatten(data, sg)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &stateData)...)
 }
 
 func (r *resourceSecurityGroupRule) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var data SecurityGroupRuleModel
-	readTimeout, diag := data.Timeouts.Read(ctx, ReadDefaultTimeout)
+	timeout, diag := data.Timeouts.Read(ctx, ReadDefaultTimeout)
 	if fwhelpers.CheckDiags(resp, diag) {
 		return
 	}
@@ -555,16 +552,13 @@ func (r *resourceSecurityGroupRule) Read(ctx context.Context, req resource.ReadR
 		return
 	}
 
-	data, err := r.read(ctx, data, readTimeout)
+	data, err := r.read(ctx, data, timeout)
 	if err != nil {
 		if errors.Is(err, ErrResourceEmpty) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(
-			"Unable to set Security Group Rule API response values.",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
@@ -578,12 +572,10 @@ func (r *resourceSecurityGroupRule) Delete(ctx context.Context, req resource.Del
 	var data SecurityGroupRuleModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
 
-	deleteTimeout, diag := data.Timeouts.Delete(ctx, DeleteDefaultTimeout)
+	timeout, diag := data.Timeouts.Delete(ctx, DeleteDefaultTimeout)
 	if fwhelpers.CheckDiags(resp, diag) {
 		return
 	}
-	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
-	defer cancel()
 
 	delReq := osc.DeleteSecurityGroupRuleRequest{
 		Flow:            data.Flow.ValueString(),
@@ -621,27 +613,17 @@ func (r *resourceSecurityGroupRule) Delete(ctx context.Context, req resource.Del
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	_, err := r.Client.DeleteSecurityGroupRule(ctx, delReq, options.WithRetryTimeout(deleteTimeout))
+	_, err := r.Client.DeleteSecurityGroupRule(ctx, delReq, options.WithRetryTimeout(timeout))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to delete Security Group Rule.",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(securityGroupRuleErrDelete, err.Error())
 	}
 }
 
-func (r *resourceSecurityGroupRule) readSecurityGroupsWithFilters(ctx context.Context, data SecurityGroupRuleModel, filter *osc.FiltersSecurityGroup) (*osc.ReadSecurityGroupsResponse, error) {
-	readTimeout, diag := data.Timeouts.Read(ctx, ReadDefaultTimeout)
-	if diag.HasError() {
-		return nil, fmt.Errorf("unable to parse 'security_group_rule' read timeout value: %v", diag.Errors())
-	}
-	ctx, cancel := context.WithTimeout(ctx, readTimeout)
-	defer cancel()
-
+func (r *resourceSecurityGroupRule) readSecurityGroupsWithFilters(ctx context.Context, timeout time.Duration, data SecurityGroupRuleModel, filter *osc.FiltersSecurityGroup) (*osc.ReadSecurityGroupsResponse, error) {
 	readReq := osc.ReadSecurityGroupsRequest{
 		Filters: filter,
 	}
-	readResp, err := r.Client.ReadSecurityGroups(ctx, readReq, options.WithRetryTimeout(readTimeout))
+	readResp, err := r.Client.ReadSecurityGroups(ctx, readReq, options.WithRetryTimeout(timeout))
 	if err != nil {
 		return nil, err
 	}
@@ -661,8 +643,12 @@ func (r *resourceSecurityGroupRule) read(ctx context.Context, data SecurityGroup
 		return data, err
 	}
 
+	return r.flatten(data, *securityGroup), nil
+}
+
+func (r *resourceSecurityGroupRule) flatten(data SecurityGroupRuleModel, securityGroup osc.SecurityGroup) SecurityGroupRuleModel {
 	data.SecurityGroupName = to.String(securityGroup.SecurityGroupName)
 	data.NetId = to.String(ptr.From(securityGroup.NetId))
 
-	return data, nil
+	return data
 }

--- a/internal/services/oapi/resource_security_group_test.go
+++ b/internal/services/oapi/resource_security_group_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -176,6 +177,28 @@ func TestAccNet_WithSecurityGroup_Migration(t *testing.T) {
 	})
 }
 
+func TestAccOthers_SecurityGroup_CreateFailureKeepsState(t *testing.T) {
+	resourceName := "outscale_security_group.recovery"
+	sgName := acctest.RandomWithPrefix("testacc-sg")
+	invalidTagKey := strings.Repeat("a", 256)
+	tagValue := "testacc-resource-security-group"
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testacc.ProtoV6ProviderFactories(),
+		Steps: testacc.CreateFailureReplacementSteps(
+			resourceName,
+			securityGroupCreateFailureConfig(sgName, invalidTagKey, tagValue),
+			securityGroupCreateFailureConfig(sgName, "Name", tagValue),
+			resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttrSet(resourceName, "security_group_id"),
+				resource.TestCheckResourceAttr(resourceName, "remove_default_outbound_rule", "true"),
+				resource.TestCheckResourceAttr(resourceName, "outbound_rules.#", "0"),
+				resource.TestCheckResourceAttr(resourceName, "tags.0.value", tagValue),
+			),
+		),
+	})
+}
+
 func testAccOutscaleSecurityGroupConfig(rInt int) string {
 	return fmt.Sprintf(`
 		resource "outscale_net" "net" {
@@ -199,6 +222,26 @@ func testAccOutscaleSecurityGroupConfig(rInt int) string {
 			net_id = outscale_net.net.id
 		}
 	`, rInt)
+}
+
+func securityGroupCreateFailureConfig(sgName, tagKey, tagValue string) string {
+	return fmt.Sprintf(`
+		resource "outscale_net" "net" {
+			ip_range = "10.0.0.0/16"
+		}
+
+		resource "outscale_security_group" "recovery" {
+			description                  = "security group create failure"
+			security_group_name          = %q
+			net_id                       = outscale_net.net.net_id
+			remove_default_outbound_rule = true
+
+			tags {
+				key   = %q
+				value = %q
+			}
+		}
+	`, sgName, tagKey, tagValue)
 }
 
 func securityGroupWithLBUConfigStep1(sgName, sgName2, lbuName string) string {

--- a/internal/services/oapi/resource_server_certificate.go
+++ b/internal/services/oapi/resource_server_certificate.go
@@ -33,10 +33,8 @@ var (
 
 const (
 	serverCertErrCreate = "Unable to create Server Certificate"
-	serverCertErrRead   = "Unable to read Server Certificate"
 	serverCertErrUpdate = "Unable to update Server Certificate"
 	serverCertErrDelete = "Unable to delete Server Certificate"
-	serverCertErrState  = "Unable to set Cerver Certificate state"
 )
 
 type serverCertificateModel struct {
@@ -207,12 +205,9 @@ func (r *serverCertificateResource) Create(ctx context.Context, req resource.Cre
 	}
 
 	data.Id = to.String(createResp.ServerCertificate.Id)
+	data.RequestId = to.String(createResp.ResponseContext.RequestId)
 
-	stateData, err := r.read(ctx, timeout, data)
-	if err != nil {
-		resp.Diagnostics.AddError(serverCertErrState, err.Error())
-		return
-	}
+	stateData := r.flatten(data, *createResp.ServerCertificate)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &stateData)...)
 }
@@ -232,7 +227,7 @@ func (r *serverCertificateResource) Read(ctx context.Context, req resource.ReadR
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(serverCertErrRead, err.Error())
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
@@ -271,7 +266,7 @@ func (r *serverCertificateResource) Update(ctx context.Context, req resource.Upd
 
 	newData, err := r.read(ctx, timeout, planData)
 	if err != nil {
-		resp.Diagnostics.AddError(serverCertErrState, err.Error())
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
@@ -315,13 +310,18 @@ func (r *serverCertificateResource) read(ctx context.Context, timeout time.Durat
 	if !ok {
 		return data, ErrResourceEmpty
 	}
+	data.RequestId = to.String(resp.ResponseContext.RequestId)
 
+	return r.flatten(data, server), nil
+}
+
+func (r *serverCertificateResource) flatten(data serverCertificateModel, server osc.ServerCertificate) serverCertificateModel {
+	data.Id = to.String(ptr.From(server.Id))
 	data.ExpirationDate = to.String(from.ISO8601(server.ExpirationDate))
 	data.Name = to.String(server.Name)
 	data.Orn = to.String(server.Orn)
 	data.Path = to.String(server.Path)
 	data.UploadDate = to.String(from.ISO8601(server.UploadDate))
-	data.RequestId = to.String(resp.ResponseContext.RequestId)
 
-	return data, nil
+	return data
 }

--- a/internal/services/oapi/resource_snapshot.go
+++ b/internal/services/oapi/resource_snapshot.go
@@ -35,12 +35,10 @@ var (
 
 const (
 	snapshotErrCreate = "Unable to create Snapshot"
-	snapshotErrRead   = "Unable to read Snapshot"
 	snapshotErrDelete = "Unable to delete Snapshot"
-	snapshotErrState  = "Unable to set Snapshot state"
 	snapshotErrWait   = "Unable to wait for Snapshot to be available"
 
-	snapshotCreateTimeout = 40 * time.Minute
+	snapshottimeout = 40 * time.Minute
 )
 
 type snapshotModel struct {
@@ -251,7 +249,7 @@ func (r *snapshotResource) Create(ctx context.Context, req resource.CreateReques
 		return
 	}
 
-	timeout, diag := data.Timeouts.Create(ctx, snapshotCreateTimeout)
+	timeout, diag := data.Timeouts.Create(ctx, snapshottimeout)
 	if fwhelpers.CheckDiags(resp, diag) {
 		return
 	}
@@ -284,8 +282,24 @@ func (r *snapshotResource) Create(ctx context.Context, req resource.CreateReques
 	}
 
 	snapshotId := createResp.Snapshot.SnapshotId
+	data.RequestId = to.String(createResp.ResponseContext.RequestId)
 	data.Id = to.String(snapshotId)
 	data.SnapshotId = to.String(snapshotId)
+
+	stateData, err := r.flatten(ctx, data, *createResp.Snapshot)
+	if err != nil {
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
+		return
+	}
+	diag = resp.State.Set(ctx, &stateData)
+	if fwhelpers.CheckDiags(resp, diag) {
+		return
+	}
+
+	diag = createOAPITagsFW(ctx, r.Client, timeout, data.Tags, snapshotId)
+	if fwhelpers.CheckDiags(resp, diag) {
+		return
+	}
 
 	stateConf := &stateconf.StateChangeConf[osc.SnapshotState]{
 		Pending: stateconf.States(
@@ -296,19 +310,15 @@ func (r *snapshotResource) Create(ctx context.Context, req resource.CreateReques
 		Timeout: timeout,
 		Refresh: r.stateRefreshFunc(snapshotId),
 	}
-	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+	snapshotAny, err := stateConf.WaitForStateContext(ctx)
+	if err != nil {
 		resp.Diagnostics.AddError(snapshotErrWait, err.Error())
 		return
 	}
 
-	diag = createOAPITagsFW(ctx, r.Client, timeout, data.Tags, snapshotId)
-	if fwhelpers.CheckDiags(resp, diag) {
-		return
-	}
-
-	stateData, err := r.read(ctx, timeout, data)
+	stateData, err = r.flatten(ctx, data, snapshotAny.(osc.Snapshot))
 	if err != nil {
-		resp.Diagnostics.AddError(snapshotErrState, err.Error())
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
@@ -330,7 +340,7 @@ func (r *snapshotResource) Read(ctx context.Context, req resource.ReadRequest, r
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(snapshotErrRead, err.Error())
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
@@ -361,7 +371,7 @@ func (r *snapshotResource) Update(ctx context.Context, req resource.UpdateReques
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(snapshotErrState, err.Error())
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
@@ -402,7 +412,12 @@ func (r *snapshotResource) read(ctx context.Context, timeout time.Duration, data
 	}
 
 	snapshot := (*resp.Snapshots)[0]
+	data.RequestId = to.String(resp.ResponseContext.RequestId)
 
+	return r.flatten(ctx, data, snapshot)
+}
+
+func (r *snapshotResource) flatten(ctx context.Context, data snapshotModel, snapshot osc.Snapshot) (snapshotModel, error) {
 	tags, diag := flattenOAPITagsFW(ctx, ptr.From(snapshot.Tags))
 	if diag.HasError() {
 		return data, from.Diag(diag)
@@ -423,7 +438,6 @@ func (r *snapshotResource) read(ctx context.Context, timeout time.Duration, data
 	data.Progress = to.Int64(ptr.From(snapshot.Progress))
 	data.State = to.String(snapshot.State)
 	data.VolumeSize = to.Int64(snapshot.VolumeSize)
-	data.RequestId = to.String(resp.ResponseContext.RequestId)
 	data.Id = to.String(snapshot.SnapshotId)
 	data.Tags = tags
 
@@ -457,6 +471,6 @@ func (r *snapshotResource) stateRefreshFunc(id string) func(context.Context) (an
 		}
 
 		snapshot := (*resp.Snapshots)[0]
-		return resp, snapshot.State, nil
+		return snapshot, snapshot.State, nil
 	}
 }

--- a/internal/services/oapi/resource_snapshot_attributes.go
+++ b/internal/services/oapi/resource_snapshot_attributes.go
@@ -37,8 +37,6 @@ var (
 
 const (
 	snapAttrErrCreate = "Unable to create Snapshot Attributes"
-	snapAttrErrRead   = "Unable to read Snapshot Attributes"
-	snapAttrErrState  = "Unable to set Snapshot Attributes state"
 )
 
 type snapshotAttributesModel struct {
@@ -237,10 +235,12 @@ func (r *snapshotAttributesResource) Create(ctx context.Context, req resource.Cr
 	}
 
 	data.Id = to.String(snapshotId)
+	// The API response does not contain enough information to set the state directly, which would cause an error.
+	// The next read will fill the state
 
 	stateData, err := r.read(ctx, timeout, data)
 	if err != nil {
-		resp.Diagnostics.AddError(snapAttrErrState, err.Error())
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
@@ -262,7 +262,7 @@ func (r *snapshotAttributesResource) Read(ctx context.Context, req resource.Read
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(snapAttrErrRead, err.Error())
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 

--- a/internal/services/oapi/resource_snapshot_test.go
+++ b/internal/services/oapi/resource_snapshot_test.go
@@ -2,6 +2,7 @@ package oapi_test
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/outscale/terraform-provider-outscale/internal/testacc"
@@ -62,6 +63,25 @@ func TestAccOthers_Snapshot_Migration(t *testing.T) {
 	})
 }
 
+func TestAccOthers_Snapshot_CreateFailureKeepsState(t *testing.T) {
+	resourceName := "outscale_snapshot.outscale_snapshot"
+	invalidTagKey := strings.Repeat("a", 256)
+	tagValue := "testacc-resource-snapshot"
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testacc.ProtoV6ProviderFactories(),
+		Steps: testacc.CreateFailureReplacementSteps(
+			resourceName,
+			snapshotConfigWithTag(invalidTagKey, tagValue),
+			snapshotConfigWithTag("Name", tagValue),
+			resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttrSet(resourceName, "snapshot_id"),
+				resource.TestCheckResourceAttr(resourceName, "tags.0.value", tagValue),
+			),
+		),
+	})
+}
+
 func snapshotConfig(addPermissions bool) string {
 	config := fmt.Sprintf(`
 resource "outscale_volume" "outscale_volume" {
@@ -86,6 +106,24 @@ resource "outscale_snapshot_attributes" "outscale_snapshot_attributes" {
 `
 	}
 	return config
+}
+
+func snapshotConfigWithTag(tagKey, tagValue string) string {
+	return fmt.Sprintf(`
+resource "outscale_volume" "outscale_volume" {
+    subregion_name = "%sa"
+    size           = 40
+}
+
+resource "outscale_snapshot" "outscale_snapshot" {
+    volume_id   = outscale_volume.outscale_volume.volume_id
+    description = "testacc-snapshot"
+    tags {
+        key   = %q
+        value = %q
+    }
+}
+`, utils.GetRegion(), tagKey, tagValue)
 }
 
 func snapshotConfigCopySnapshot() string {

--- a/internal/services/oapi/resource_subnet.go
+++ b/internal/services/oapi/resource_subnet.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -19,6 +20,7 @@ import (
 	"github.com/outscale/osc-sdk-go/v3/pkg/osc"
 	"github.com/outscale/terraform-provider-outscale/internal/client"
 	"github.com/outscale/terraform-provider-outscale/internal/framework/fwhelpers"
+	"github.com/outscale/terraform-provider-outscale/internal/framework/fwhelpers/from"
 	"github.com/outscale/terraform-provider-outscale/internal/framework/fwhelpers/to"
 	"github.com/outscale/terraform-provider-outscale/internal/framework/modifyplans"
 	"github.com/outscale/terraform-provider-outscale/internal/framework/stateconf"
@@ -30,6 +32,13 @@ var (
 	_ resource.ResourceWithConfigure   = &resourceSubnet{}
 	_ resource.ResourceWithImportState = &resourceSubnet{}
 	_ resource.ResourceWithModifyPlan  = &resourceSubnet{}
+)
+
+const (
+	subnetErrCreate = "Unable to create Subnet"
+	subnetErrUpdate = "Unable to update Subnet"
+	subnetErrDelete = "Unable to delete Subnet"
+	subnetErrWait   = "Unable to wait for Subnet state"
 )
 
 type SubnetModel struct {
@@ -182,7 +191,7 @@ func (r *resourceSubnet) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
-	createTimeout, diags := data.Timeouts.Create(ctx, CreateDefaultTimeout)
+	timeout, diags := data.Timeouts.Create(ctx, CreateDefaultTimeout)
 	if fwhelpers.CheckDiags(resp, diags) {
 		return
 	}
@@ -196,18 +205,27 @@ func (r *resourceSubnet) Create(ctx context.Context, req resource.CreateRequest,
 		createReq.SubregionName = data.SubregionName.ValueStringPointer()
 	}
 
-	createResp, err := r.Client.CreateSubnet(ctx, createReq, options.WithRetryTimeout(createTimeout))
+	createResp, err := r.Client.CreateSubnet(ctx, createReq, options.WithRetryTimeout(timeout))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to create subnet resource.",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(subnetErrCreate, err.Error())
 		return
 	}
 	data.RequestId = to.String(*createResp.ResponseContext.RequestId)
 	subnet := ptr.From(createResp.Subnet)
+	data.SubnetId = to.String(subnet.SubnetId)
+	data.Id = to.String(subnet.SubnetId)
 
-	diag := createOAPITagsFW(ctx, r.Client, createTimeout, data.Tags, subnet.SubnetId)
+	stateData, err := r.flatten(ctx, data, subnet)
+	if err != nil {
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
+		return
+	}
+	diags = resp.State.Set(ctx, &stateData)
+	if fwhelpers.CheckDiags(resp, diags) {
+		return
+	}
+
+	diag := createOAPITagsFW(ctx, r.Client, timeout, data.Tags, subnet.SubnetId)
 	if fwhelpers.CheckDiags(resp, diag) {
 		return
 	}
@@ -217,7 +235,7 @@ func (r *resourceSubnet) Create(ctx context.Context, req resource.CreateRequest,
 	stateConf := &stateconf.StateChangeConf[osc.SubnetState]{
 		Pending: stateconf.States(osc.SubnetStatePending),
 		Target:  stateconf.States(osc.SubnetStateAvailable),
-		Timeout: createTimeout,
+		Timeout: timeout,
 		Refresh: func(ctx context.Context) (any, osc.SubnetState, error) {
 			resp, err := r.Client.ReadSubnets(ctx, readReq)
 			if err != nil {
@@ -233,10 +251,7 @@ func (r *resourceSubnet) Create(ctx context.Context, req resource.CreateRequest,
 	}
 
 	if _, err = stateConf.WaitForStateContext(ctx); err != nil {
-		resp.Diagnostics.AddError(
-			"Error waiting for Subnet to be ready.",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(subnetErrWait, err.Error())
 		return
 	}
 
@@ -247,22 +262,16 @@ func (r *resourceSubnet) Create(ctx context.Context, req resource.CreateRequest,
 			SubnetId:            data.SubnetId.ValueString(),
 			MapPublicIpOnLaunch: data.MapPublicIpOnLaunch.ValueBool(),
 		}
-		_, err := r.Client.UpdateSubnet(ctx, updateReq, options.WithRetryTimeout(createTimeout))
+		_, err := r.Client.UpdateSubnet(ctx, updateReq, options.WithRetryTimeout(timeout))
 		if err != nil {
-			resp.Diagnostics.AddError(
-				"Unable to update MapPublicIpOnLaunch.",
-				err.Error(),
-			)
+			resp.Diagnostics.AddError(subnetErrUpdate, err.Error())
 			return
 		}
 	}
 
-	data, err = r.read(ctx, data)
+	data, err = r.read(ctx, timeout, data)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to set subnet state.",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -276,16 +285,18 @@ func (r *resourceSubnet) Read(ctx context.Context, req resource.ReadRequest, res
 		return
 	}
 
-	data, err := r.read(ctx, data)
+	timeout, diags := data.Timeouts.Read(ctx, ReadDefaultTimeout)
+	if fwhelpers.CheckDiags(resp, diags) {
+		return
+	}
+
+	data, err := r.read(ctx, timeout, data)
 	if err != nil {
 		if errors.Is(err, ErrResourceEmpty) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(
-			"Unable to set subnet API response values.",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -308,31 +319,20 @@ func (r *resourceSubnet) Update(ctx context.Context, req resource.UpdateRequest,
 		return
 	}
 
-	updateTimeout, diags := planData.Timeouts.Update(ctx, UpdateDefaultTimeout)
-	if fwhelpers.CheckDiags(resp, diags) {
-		return
-	}
-
 	updateReq := osc.UpdateSubnetRequest{
 		SubnetId:            stateData.SubnetId.ValueString(),
 		MapPublicIpOnLaunch: planData.MapPublicIpOnLaunch.ValueBool(),
 	}
-	_, err := r.Client.UpdateSubnet(ctx, updateReq, options.WithRetryTimeout(updateTimeout))
+	_, err := r.Client.UpdateSubnet(ctx, updateReq, options.WithRetryTimeout(timeout))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to update subnet resource",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(subnetErrUpdate, err.Error())
 		return
 	}
 
 	stateData.Timeouts = planData.Timeouts
-	data, err := r.read(ctx, stateData)
+	data, err := r.read(ctx, timeout, stateData)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to set subnet state.",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, data)...)
@@ -346,7 +346,7 @@ func (r *resourceSubnet) Delete(ctx context.Context, req resource.DeleteRequest,
 		return
 	}
 
-	deleteTimeout, diags := data.Timeouts.Delete(ctx, DeleteDefaultTimeout)
+	timeout, diags := data.Timeouts.Delete(ctx, DeleteDefaultTimeout)
 	if fwhelpers.CheckDiags(resp, diags) {
 		return
 	}
@@ -357,23 +357,16 @@ func (r *resourceSubnet) Delete(ctx context.Context, req resource.DeleteRequest,
 
 	// Retry on 409 (subnet in-use) as API can take time to see a subnet as not in use anymore
 	_, err := oapihelpers.RetryOnCodes(ctx, []string{"9095"}, func() (resp any, err error) {
-		return r.Client.DeleteSubnet(ctx, delReq, options.WithRetryTimeout(deleteTimeout))
-	}, deleteTimeout)
+		return r.Client.DeleteSubnet(ctx, delReq, options.WithRetryTimeout(timeout))
+	}, timeout)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to Delete subnet.",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(subnetErrDelete, err.Error())
 		return
 	}
 }
 
-func (r *resourceSubnet) read(ctx context.Context, data SubnetModel) (SubnetModel, error) {
-	readTimeout, diags := data.Timeouts.Read(ctx, ReadDefaultTimeout)
-	if diags.HasError() {
-		return data, fmt.Errorf("unable to parse 'subnet' read timeout value: %v", diags.Errors())
-	}
-	ctxWithTimeout, cancel := context.WithTimeout(ctx, readTimeout)
+func (r *resourceSubnet) read(ctx context.Context, timeout time.Duration, data SubnetModel) (SubnetModel, error) {
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	subnet, err := r.Batcher.Read(ctxWithTimeout, data.SubnetId.ValueString())
@@ -384,9 +377,13 @@ func (r *resourceSubnet) read(ctx context.Context, data SubnetModel) (SubnetMode
 		return data, err
 	}
 
+	return r.flatten(ctx, data, *subnet)
+}
+
+func (r *resourceSubnet) flatten(ctx context.Context, data SubnetModel, subnet osc.Subnet) (SubnetModel, error) {
 	tags, diags := flattenOAPITagsFW(ctx, subnet.Tags)
 	if diags.HasError() {
-		return data, fmt.Errorf("unable to flatten tags: %v", diags.Errors())
+		return data, from.Diag(diags)
 	}
 	data.Tags = tags
 

--- a/internal/services/oapi/resource_subnet_test.go
+++ b/internal/services/oapi/resource_subnet_test.go
@@ -2,6 +2,7 @@ package oapi_test
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -37,7 +38,30 @@ func TestAccNet_WithSubNet_Basic_Migration(t *testing.T) {
 	})
 }
 
+func TestAccNet_Subnet_CreateFailureKeepsState(t *testing.T) {
+	resourceName := "outscale_subnet.subnet"
+	invalidTagKey := strings.Repeat("a", 256)
+	tagValue := "testacc-create-failure"
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testacc.ProtoV6ProviderFactories(),
+		Steps: testacc.CreateFailureReplacementSteps(
+			resourceName,
+			testAccOutscaleSubnetConfigWithTag(utils.GetRegion(), false, invalidTagKey, tagValue),
+			testAccOutscaleSubnetConfigWithTag(utils.GetRegion(), false, "name", tagValue),
+			resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttrSet(resourceName, "subnet_id"),
+				resource.TestCheckResourceAttr(resourceName, "tags.0.value", tagValue),
+			),
+		),
+	})
+}
+
 func testAccOutscaleSubnetConfig(region string, mapPublicIpOnLaunch bool) string {
+	return testAccOutscaleSubnetConfigWithTag(region, mapPublicIpOnLaunch, "name", "terraform-subnet")
+}
+
+func testAccOutscaleSubnetConfigWithTag(region string, mapPublicIpOnLaunch bool, tagKey, tagValue string) string {
 	return fmt.Sprintf(`
 		resource "outscale_net" "net" {
 			ip_range = "10.0.0.0/16"
@@ -54,9 +78,9 @@ func testAccOutscaleSubnetConfig(region string, mapPublicIpOnLaunch bool) string
 			net_id         = outscale_net.net.id
 			map_public_ip_on_launch = %v
 			tags {
-				key   = "name"
-				value = "terraform-subnet"
+				key   = %q
+				value = %q
 			}
 		}
-	`, region, mapPublicIpOnLaunch)
+	`, region, mapPublicIpOnLaunch, tagKey, tagValue)
 }

--- a/internal/services/oapi/resource_user.go
+++ b/internal/services/oapi/resource_user.go
@@ -35,6 +35,15 @@ var (
 	_ resource.ResourceWithImportState = &resourceUser{}
 )
 
+const (
+	userErrCreate  = "Unable to create User"
+	userErrUpdate  = "Unable to update User"
+	userErrDelete  = "Unable to delete User"
+	userErrUnlink  = "Unable to unlink policy from User"
+	userErrLink    = "Unable to link policy to User"
+	userErrDefault = "Unable to set default policy version for User policy"
+)
+
 type UserModel struct {
 	CreationDate         types.String   `tfsdk:"creation_date"`
 	LastModificationDate types.String   `tfsdk:"last_modification_date"`
@@ -177,7 +186,7 @@ func (r *resourceUser) Create(ctx context.Context, req resource.CreateRequest, r
 	var data UserModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
 
-	createTimeout, diag := data.Timeouts.Create(ctx, CreateDefaultTimeout)
+	timeout, diag := data.Timeouts.Create(ctx, CreateDefaultTimeout)
 	if fwhelpers.CheckDiags(resp, diag) {
 		return
 	}
@@ -191,33 +200,37 @@ func (r *resourceUser) Create(ctx context.Context, req resource.CreateRequest, r
 		createReq.UserEmail = data.UserEmail.ValueStringPointer()
 	}
 
-	createResp, err := r.Client.CreateUser(ctx, createReq, options.WithRetryTimeout(createTimeout))
+	createResp, err := r.Client.CreateUser(ctx, createReq, options.WithRetryTimeout(timeout))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to create User",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(userErrCreate, err.Error())
 		return
 	}
 	data.Id = to.String(createResp.User.UserId)
+
+	stateData, err := r.flatten(ctx, timeout, data, *createResp.User, nil)
+	if err != nil {
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
+		return
+	}
+	diag = resp.State.Set(ctx, &stateData)
+	if fwhelpers.CheckDiags(resp, diag) {
+		return
+	}
 
 	if fwhelpers.IsSet(data.Policies) {
 		policies, diag := to.Slice[UserPolicyModel](ctx, data.Policies)
 		if fwhelpers.CheckDiags(resp, diag) {
 			return
 		}
-		diag = r.linkPolicies(ctx, createTimeout, data.UserName.ValueString(), policies)
+		diag = r.linkPolicies(ctx, timeout, data.UserName.ValueString(), policies)
 		if fwhelpers.CheckDiags(resp, diag) {
 			return
 		}
 	}
 
-	stateData, err := r.read(ctx, createTimeout, data)
+	stateData, err = r.read(ctx, timeout, data)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to set User state",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
@@ -249,10 +262,7 @@ func (r *resourceUser) Read(ctx context.Context, req resource.ReadRequest, resp 
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(
-			"Unable to set User API response values",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
@@ -298,10 +308,7 @@ func (r *resourceUser) Update(ctx context.Context, req resource.UpdateRequest, r
 	if updateUser {
 		_, err := r.Client.UpdateUser(ctx, updateReq, options.WithRetryTimeout(timeout))
 		if err != nil {
-			resp.Diagnostics.AddError(
-				"Unable to update User",
-				err.Error(),
-			)
+			resp.Diagnostics.AddError(userErrUpdate, err.Error())
 		}
 	}
 
@@ -312,10 +319,7 @@ func (r *resourceUser) Update(ctx context.Context, req resource.UpdateRequest, r
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(
-			"Unable to set User API response values",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
@@ -356,10 +360,7 @@ func (r *resourceUser) unlinkPolicies(ctx context.Context, timeout time.Duration
 
 		_, err := r.Client.UnlinkPolicy(ctx, req, options.WithRetryTimeout(timeout))
 		if err != nil {
-			diags.AddError(
-				"Unable to unlink policy from User",
-				err.Error(),
-			)
+			diags.AddError(userErrUnlink, err.Error())
 			return diags
 		}
 	}
@@ -378,20 +379,14 @@ func (r *resourceUser) linkPolicies(ctx context.Context, timeout time.Duration, 
 
 		_, err := r.Client.LinkPolicy(ctx, req, options.WithRetryTimeout(timeout))
 		if err != nil {
-			diags.AddError(
-				"Unable to link policy to User",
-				err.Error(),
-			)
+			diags.AddError(userErrLink, err.Error())
 			return diags
 		}
 
 		if fwhelpers.IsSet(policy.DefaultVersionId) {
 			err := r.setDefaultPolicyVersion(ctx, timeout, policy.PolicyOrn.ValueString(), policy.DefaultVersionId.ValueString())
 			if err != nil {
-				diags.AddError(
-					"Unable to set default policy version for policy linked to User",
-					err.Error(),
-				)
+				diags.AddError(userErrDefault, err.Error())
 				return diags
 			}
 		}
@@ -427,10 +422,7 @@ func (r *resourceUser) Delete(ctx context.Context, req resource.DeleteRequest, r
 
 	_, err := r.Client.DeleteUser(ctx, deleteReq, options.WithRetryTimeout(timeout))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to delete User",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(userErrDelete, err.Error())
 	}
 }
 
@@ -458,14 +450,18 @@ func (r *resourceUser) read(ctx context.Context, timeout time.Duration, data Use
 		return data, err
 	}
 
-	policies, err := r.flattenPolicies(ctx, timeout, ptr.From(linkResp.Policies))
+	return r.flatten(ctx, timeout, data, user, ptr.From(linkResp.Policies))
+}
+
+func (r *resourceUser) flatten(ctx context.Context, timeout time.Duration, data UserModel, user osc.User, linkedPolicies []osc.LinkedPolicy) (UserModel, error) {
+	policies, err := r.flattenPolicies(ctx, timeout, linkedPolicies)
 	if err != nil {
 		return data, err
 	}
 
 	policiesSet, diag := to.SetObject(ctx, policies)
 	if diag.HasError() {
-		return data, fmt.Errorf("unable to convert policies to a set: %v", diag.Errors())
+		return data, from.Diag(diag)
 	}
 
 	data.Policies = policiesSet
@@ -496,6 +492,7 @@ func (r *UserCommon) flattenPolicies(ctx context.Context, timeout time.Duration,
 			LastModificationDate: to.String(from.ISO8601(policy.LastModificationDate)),
 		})
 	}
+
 	return flattenedPolicies, nil
 }
 

--- a/internal/services/oapi/resource_user_group.go
+++ b/internal/services/oapi/resource_user_group.go
@@ -35,6 +35,17 @@ var (
 	_ resource.ResourceWithImportState = &resourceUserGroup{}
 )
 
+const (
+	userGroupErrCreate  = "Unable to create User Group"
+	userGroupErrUpdate  = "Unable to update User Group"
+	userGroupErrDelete  = "Unable to delete User Group"
+	userGroupErrAddUser = "Unable to add user to User Group"
+	userGroupErrRmUser  = "Unable to remove user from User Group"
+	userGroupErrUnlink  = "Unable to unlink policy from User Group"
+	userGroupErrLink    = "Unable to link policy to User Group"
+	userGroupErrDefault = "Unable to set default policy version for User Group policy"
+)
+
 type UserGroupModel struct {
 	CreationDate         types.String   `tfsdk:"creation_date"`
 	LastModificationDate types.String   `tfsdk:"last_modification_date"`
@@ -201,7 +212,7 @@ func (r *resourceUserGroup) Create(ctx context.Context, req resource.CreateReque
 	var data UserGroupModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
 
-	createTimeout, diag := data.Timeouts.Create(ctx, CreateDefaultTimeout)
+	timeout, diag := data.Timeouts.Create(ctx, CreateDefaultTimeout)
 	if fwhelpers.CheckDiags(resp, diag) {
 		return
 	}
@@ -211,16 +222,22 @@ func (r *resourceUserGroup) Create(ctx context.Context, req resource.CreateReque
 		Path:          new(data.Path.ValueString()),
 	}
 
-	createResp, err := r.Client.CreateUserGroup(ctx, createReq, options.WithRetryTimeout(createTimeout))
+	createResp, err := r.Client.CreateUserGroup(ctx, createReq, options.WithRetryTimeout(timeout))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to create User Group",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(userGroupErrCreate, err.Error())
 		return
 	}
-
 	data.Id = to.String(createResp.UserGroup.UserGroupId)
+
+	stateData, err := r.flatten(ctx, timeout, data, *createResp.UserGroup, nil, nil)
+	if err != nil {
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
+		return
+	}
+	diag = resp.State.Set(ctx, &stateData)
+	if fwhelpers.CheckDiags(resp, diag) {
+		return
+	}
 
 	if fwhelpers.IsSet(data.Users) {
 		users, diag := to.Slice[UserGroupUserModel](ctx, data.Users)
@@ -228,7 +245,7 @@ func (r *resourceUserGroup) Create(ctx context.Context, req resource.CreateReque
 			return
 		}
 
-		diag = r.addUsers(ctx, createTimeout, data.UserGroupName.ValueString(), data.Path.ValueString(), users)
+		diag = r.addUsers(ctx, timeout, data.UserGroupName.ValueString(), data.Path.ValueString(), users)
 		if fwhelpers.CheckDiags(resp, diag) {
 			return
 		}
@@ -239,18 +256,15 @@ func (r *resourceUserGroup) Create(ctx context.Context, req resource.CreateReque
 			return
 		}
 
-		diag = r.linkPolicies(ctx, createTimeout, data.UserGroupName.ValueString(), policies)
+		diag = r.linkPolicies(ctx, timeout, data.UserGroupName.ValueString(), policies)
 		if fwhelpers.CheckDiags(resp, diag) {
 			return
 		}
 	}
 
-	stateData, err := r.read(ctx, createTimeout, data)
+	stateData, err = r.read(ctx, timeout, data)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to set User state",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
@@ -272,10 +286,7 @@ func (r *resourceUserGroup) Read(ctx context.Context, req resource.ReadRequest, 
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(
-			"Unable to set User API response values",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
@@ -324,10 +335,7 @@ func (r *resourceUserGroup) Update(ctx context.Context, req resource.UpdateReque
 	if updateGroup {
 		_, err := r.Client.UpdateUserGroup(ctx, updateReq, options.WithRetryTimeout(timeout))
 		if err != nil {
-			resp.Diagnostics.AddError(
-				"Unable to update User Group",
-				err.Error(),
-			)
+			resp.Diagnostics.AddError(userGroupErrUpdate, err.Error())
 		}
 	}
 
@@ -338,10 +346,7 @@ func (r *resourceUserGroup) Update(ctx context.Context, req resource.UpdateReque
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(
-			"Unable to set User Group API response values",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
@@ -364,10 +369,7 @@ func (r *resourceUserGroup) Delete(ctx context.Context, req resource.DeleteReque
 
 	_, err := r.Client.DeleteUserGroup(ctx, deleteReq, options.WithRetryTimeout(timeout))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to delete User Group",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(userGroupErrDelete, err.Error())
 	}
 }
 
@@ -405,6 +407,10 @@ func (r *resourceUserGroup) read(ctx context.Context, timeout time.Duration, dat
 		return data, err
 	}
 
+	return r.flatten(ctx, timeout, data, userGroup, ptr.From(respLink.Policies), ptr.From(respUsers.Users))
+}
+
+func (r *resourceUserGroup) flatten(ctx context.Context, timeout time.Duration, data UserGroupModel, userGroup osc.UserGroup, policies []osc.LinkedPolicy, users []osc.User) (UserGroupModel, error) {
 	data.UserGroupName = to.String(userGroup.Name)
 	data.Path = to.String(userGroup.Path)
 	data.UserGroupId = to.String(userGroup.UserGroupId)
@@ -413,20 +419,20 @@ func (r *resourceUserGroup) read(ctx context.Context, timeout time.Duration, dat
 	data.CreationDate = to.String(from.ISO8601(ptr.From(userGroup.CreationDate)))
 	data.LastModificationDate = to.String(from.ISO8601(userGroup.LastModificationDate))
 
-	policies, err := r.flattenPolicies(ctx, timeout, ptr.From(respLink.Policies))
+	policiesModel, err := r.flattenPolicies(ctx, timeout, policies)
 	if err != nil {
 		return data, err
 	}
-	policiesSet, diag := to.SetObject(ctx, policies)
+	policiesSet, diag := to.SetObject(ctx, policiesModel)
 	if diag.HasError() {
-		return data, fmt.Errorf("unable to convert policies to a set: %v", diag.Errors())
+		return data, from.Diag(diag)
 	}
 	data.Policies = policiesSet
 
-	users := r.flattenUsers(ptr.From(respUsers.Users))
-	usersSet, diag := to.SetObject(ctx, users)
+	usersModel := r.flattenUsers(users)
+	usersSet, diag := to.SetObject(ctx, usersModel)
 	if diag.HasError() {
-		return data, fmt.Errorf("unable to convert users to a set: %v", diag.Errors())
+		return data, from.Diag(diag)
 	}
 	data.Users = usersSet
 
@@ -451,10 +457,7 @@ func (r *resourceUserGroup) addUsers(ctx context.Context, timeout time.Duration,
 
 		_, err := r.Client.AddUserToUserGroup(ctx, req, options.WithRetryTimeout(timeout))
 		if err != nil {
-			diags.AddError(
-				"Unable to add user to User Group",
-				err.Error(),
-			)
+			diags.AddError(userGroupErrAddUser, err.Error())
 			return diags
 		}
 	}
@@ -487,10 +490,7 @@ func (r *resourceUserGroup) removeUsers(ctx context.Context, timeout time.Durati
 			if errCode.Code == "5098" {
 				continue
 			}
-			diags.AddError(
-				"Unable to remove user from User Group",
-				err.Error(),
-			)
+			diags.AddError(userGroupErrRmUser, err.Error())
 			return diags
 		}
 	}
@@ -554,10 +554,7 @@ func (r *resourceUserGroup) unlinkPolicies(ctx context.Context, timeout time.Dur
 
 		_, err := r.Client.UnlinkManagedPolicyFromUserGroup(ctx, req, options.WithRetryTimeout(timeout))
 		if err != nil {
-			diags.AddError(
-				"Unable to unlink policy from User Group",
-				err.Error(),
-			)
+			diags.AddError(userGroupErrUnlink, err.Error())
 			return diags
 		}
 	}
@@ -576,20 +573,14 @@ func (r *resourceUserGroup) linkPolicies(ctx context.Context, timeout time.Durat
 
 		_, err := r.Client.LinkManagedPolicyToUserGroup(ctx, req, options.WithRetryTimeout(timeout))
 		if err != nil {
-			diags.AddError(
-				"Unable to link policy to User Group",
-				err.Error(),
-			)
+			diags.AddError(userGroupErrLink, err.Error())
 			return diags
 		}
 
 		if fwhelpers.IsSet(policy.DefaultVersionId) {
 			err := r.setDefaultPolicyVersion(ctx, timeout, policy.PolicyOrn.ValueString(), policy.DefaultVersionId.ValueString())
 			if err != nil {
-				diags.AddError(
-					"Unable to set default policy version for policy linked to User Group",
-					err.Error(),
-				)
+				diags.AddError(userGroupErrDefault, err.Error())
 				return diags
 			}
 		}

--- a/internal/services/oapi/resource_user_group_test.go
+++ b/internal/services/oapi/resource_user_group_test.go
@@ -106,6 +106,51 @@ func TestAccOthers_UserGroup_WithPolicy(t *testing.T) {
 	})
 }
 
+func TestAccOthers_UserGroup_CreateFailureKeepsState(t *testing.T) {
+	resourceName := "outscale_user_group.userGroupAcc"
+	groupName := acctest.RandomWithPrefix("testacc-ug")
+	invalidUserName := acctest.RandomWithPrefix("testacc-missing-user")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testacc.ProtoV6ProviderFactories(),
+		Steps: testacc.CreateFailureReplacementSteps(
+			resourceName,
+			testAccUserGroupWithInvalidUser(groupName, invalidUserName),
+			testAccUserGroupBasicConfigWithResourceName("userGroupAcc", groupName),
+			resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttrSet(resourceName, "user_group_name"),
+				resource.TestCheckResourceAttr(resourceName, "user_group_name", groupName),
+				resource.TestCheckResourceAttr(resourceName, "path", "/"),
+				resource.TestCheckResourceAttr(resourceName, "user.#", "0"),
+				resource.TestCheckResourceAttr(resourceName, "policy.#", "0"),
+			),
+		),
+	})
+}
+
+func TestAccOthers_UserGroup_CreatePolicyFailureKeepsState(t *testing.T) {
+	resourceName := "outscale_user_group.userGroupAccPolicyFailure"
+	groupName := acctest.RandomWithPrefix("testacc-ug")
+	userName := acctest.RandomWithPrefix("testacc-user")
+	invalidPolicyOrn := fmt.Sprintf("orn:ows:iam::000000000000:policy/%s", acctest.RandomWithPrefix("testacc-missing-policy"))
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testacc.ProtoV6ProviderFactories(),
+		Steps: testacc.CreateFailureReplacementSteps(
+			resourceName,
+			testAccUserGroupWithInvalidPolicy(groupName, userName, invalidPolicyOrn),
+			testAccUserGroupWithUsersConfigAndResourceName("userGroupAccPolicyFailure", groupName, userName),
+			resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttrSet(resourceName, "user_group_name"),
+				resource.TestCheckResourceAttr(resourceName, "user_group_name", groupName),
+				resource.TestCheckResourceAttr(resourceName, "path", "/"),
+				resource.TestCheckResourceAttr(resourceName, "user.#", "1"),
+				resource.TestCheckResourceAttr(resourceName, "policy.#", "0"),
+			),
+		),
+	})
+}
+
 func TestAccOthers_UserGroup_Migration(t *testing.T) {
 	groupName := acctest.RandomWithPrefix("testacc-ug")
 
@@ -115,11 +160,15 @@ func TestAccOthers_UserGroup_Migration(t *testing.T) {
 }
 
 func testAccUserGroupBasicConfig(name string) string {
+	return testAccUserGroupBasicConfigWithResourceName("basic_group", name)
+}
+
+func testAccUserGroupBasicConfigWithResourceName(resourceName, name string) string {
 	return fmt.Sprintf(`
-	resource "outscale_user_group" "basic_group" {
+	resource "outscale_user_group" %q {
 	  user_group_name = "%s"
 	  path = "/"
-	}`, name)
+	}`, resourceName, name)
 }
 
 func testAccUserGroupWithUsers(groupName, userName1, userName2 string) string {
@@ -145,6 +194,23 @@ func testAccUserGroupWithUsers(groupName, userName1, userName2 string) string {
 			}
 		}
 	`, userName1, userName2, groupName)
+}
+
+func testAccUserGroupWithUsersConfigAndResourceName(resourceName, groupName, userName string) string {
+	return fmt.Sprintf(`
+		resource "outscale_user" "userToAdd1" {
+			user_name = %q
+			path = "/"
+		}
+
+		resource "outscale_user_group" %q {
+			user_group_name = %q
+			path = "/"
+			user {
+				user_name = outscale_user.userToAdd1.user_name
+			}
+		}
+	`, userName, resourceName, groupName)
 }
 
 func testAccUserGroupWithPolicy(groupName, userName1, userName2, policyName string) string {
@@ -206,4 +272,36 @@ func testAccUserGroupUpdate(groupName, userName1, userName2 string) string {
 			depends_on = [outscale_user.userUpToAdd01]
 		}
 	`, userName1, userName2, groupName, userName1)
+}
+
+func testAccUserGroupWithInvalidUser(groupName, userName string) string {
+	return fmt.Sprintf(`
+		resource "outscale_user_group" "userGroupAcc" {
+			user_group_name = "%s"
+			path = "/"
+			user {
+				user_name = "%s"
+			}
+		}
+	`, groupName, userName)
+}
+
+func testAccUserGroupWithInvalidPolicy(groupName, userName, policyOrn string) string {
+	return fmt.Sprintf(`
+		resource "outscale_user" "userToAdd1" {
+			user_name = %q
+			path = "/"
+		}
+
+		resource "outscale_user_group" "userGroupAccPolicyFailure" {
+			user_group_name = %q
+			path = "/"
+			user {
+				user_name = outscale_user.userToAdd1.user_name
+			}
+			policy {
+				policy_orn = %q
+			}
+		}
+	`, userName, groupName, policyOrn)
 }

--- a/internal/services/oapi/resource_user_test.go
+++ b/internal/services/oapi/resource_user_test.go
@@ -109,17 +109,41 @@ func TestAccOthers_User_Migration(t *testing.T) {
 	})
 }
 
+func TestAccOthers_User_CreatePolicyFailureKeepsState(t *testing.T) {
+	resourceName := "outscale_user.user_policy_failure"
+	userName := acctest.RandomWithPrefix("testacc-user")
+	invalidPolicyOrn := fmt.Sprintf("orn:ows:iam::000000000000:policy/%s", acctest.RandomWithPrefix("testacc-missing-policy"))
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testacc.ProtoV6ProviderFactories(),
+		Steps: testacc.CreateFailureReplacementSteps(
+			resourceName,
+			testAccUserWithInvalidPolicy(userName, invalidPolicyOrn),
+			testAccUserBasicConfigWithResourceName("user_policy_failure", userName),
+			resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttrSet(resourceName, "user_id"),
+				resource.TestCheckResourceAttr(resourceName, "user_name", userName),
+				resource.TestCheckResourceAttr(resourceName, "policy.#", "0"),
+			),
+		),
+	})
+}
+
 func testAccOutscaleUserBasicConfig(userName string) string {
+	return testAccUserBasicConfigWithResourceName("basic_user", userName)
+}
+
+func testAccUserBasicConfigWithResourceName(resourceName, userName string) string {
 	return fmt.Sprintf(`
-    resource "outscale_access_key" "access_key01" {
+	resource "outscale_access_key" "access_key01" {
 		state       = "ACTIVE"
-		user_name   = outscale_user.basic_user.user_name
-		depends_on  = [outscale_user.basic_user]
+		user_name   = outscale_user.%s.user_name
+		depends_on  = [outscale_user.%s]
 	}
-	resource "outscale_user" "basic_user" {
+	resource "outscale_user" %q {
 		user_name = "%s"
 		path = "/"
-	}`, userName)
+	}`, resourceName, resourceName, resourceName, userName)
 }
 
 func testAccOutscaleUserUpdatedConfig(name string) string {
@@ -173,4 +197,16 @@ func testAccUserWithPolicyVersionUpper(policyName, userName string) string {
 			}
 		}
 	`, policyName, userName)
+}
+
+func testAccUserWithInvalidPolicy(userName, policyOrn string) string {
+	return fmt.Sprintf(`
+		resource "outscale_user" "user_policy_failure" {
+			user_name = %q
+			path = "/"
+			policy {
+				policy_orn = %q
+			}
+		}
+	`, userName, policyOrn)
 }

--- a/internal/services/oapi/resource_volume.go
+++ b/internal/services/oapi/resource_volume.go
@@ -40,6 +40,16 @@ var (
 	_ resource.ResourceWithModifyPlan  = &resourceVolume{}
 )
 
+const (
+	volumeErrCreate   = "Unable to create Volume"
+	volumeErrUpdate   = "Unable to update Volume"
+	volumeErrDelete   = "Unable to delete Volume"
+	volumeErrWait     = "Unable to wait for Volume state"
+	volumeErrTask     = "Unable to wait for Volume update task"
+	volumeErrSnapshot = "Unable to create snapshot during Volume deletion"
+	volumeErrTags     = "Unable to create snapshot tags during Volume deletion"
+)
+
 type VolumeModel struct {
 	TerminationSnapshotName types.String   `tfsdk:"termination_snapshot_name"`
 	LinkedVolumes           types.Set      `tfsdk:"linked_volumes"`
@@ -265,7 +275,7 @@ func (r *resourceVolume) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
-	createTimeout, diags := data.Timeouts.Create(ctx, CreateDefaultTimeout)
+	timeout, diags := data.Timeouts.Create(ctx, CreateDefaultTimeout)
 	if fwhelpers.CheckDiags(resp, diags) {
 		return
 	}
@@ -284,20 +294,27 @@ func (r *resourceVolume) Create(ctx context.Context, req resource.CreateRequest,
 		createReq.SnapshotId = data.SnapshotId.ValueStringPointer()
 	}
 
-	createResp, err := r.Client.CreateVolume(ctx, createReq, options.WithRetryTimeout(createTimeout))
+	createResp, err := r.Client.CreateVolume(ctx, createReq, options.WithRetryTimeout(timeout))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to create volume resource",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(volumeErrCreate, err.Error())
 		return
 	}
-	data.RequestId = to.String(*createResp.ResponseContext.RequestId)
 	volumeId := createResp.Volume.VolumeId
+	data.RequestId = to.String(createResp.ResponseContext.RequestId)
 	data.VolumeId = to.String(volumeId)
 	data.Id = to.String(volumeId)
 
-	diag := createOAPITagsFW(ctx, r.Client, createTimeout, data.Tags, volumeId)
+	stateData, err := r.flatten(ctx, data, *createResp.Volume)
+	if err != nil {
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
+		return
+	}
+	diags = resp.State.Set(ctx, &stateData)
+	if fwhelpers.CheckDiags(resp, diags) {
+		return
+	}
+
+	diag := createOAPITagsFW(ctx, r.Client, timeout, data.Tags, volumeId)
 	if fwhelpers.CheckDiags(resp, diag) {
 		return
 	}
@@ -305,26 +322,26 @@ func (r *resourceVolume) Create(ctx context.Context, req resource.CreateRequest,
 	stateConf := &stateconf.StateChangeConf[osc.VolumeState]{
 		Pending: stateconf.States(osc.VolumeStateCreating),
 		Target:  stateconf.States(osc.VolumeStateAvailable),
-		Timeout: createTimeout,
+		Timeout: timeout,
 		Refresh: r.stateRefreshFunc(volumeId),
 	}
-	if _, err = stateConf.WaitForStateContext(ctx); err != nil {
-		resp.Diagnostics.AddError(
-			"Waiting for volume state to become available",
+	volumeAny, err := stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError(volumeErrWait,
 			fmt.Sprintf("Unexpected volume (%s) state: '%s' ", volumeId, err.Error()),
 		)
 		return
 	}
 
-	err = setVolumeState(ctx, r, &data)
+	// We set the last read response to the state
+	volume := volumeAny.(osc.Volume)
+	stateData, err = r.flatten(ctx, data, volume)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to set volume state",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateData)...)
 }
 
 func (r *resourceVolume) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -335,19 +352,22 @@ func (r *resourceVolume) Read(ctx context.Context, req resource.ReadRequest, res
 		return
 	}
 
-	err := setVolumeState(ctx, r, &data)
+	timeout, diags := data.Timeouts.Read(ctx, ReadDefaultTimeout)
+	if fwhelpers.CheckDiags(resp, diags) {
+		return
+	}
+
+	stateData, err := r.read(ctx, timeout, data)
 	if err != nil {
 		if errors.Is(err, ErrResourceEmpty) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(
-			"Unable to set volume API response values.",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateData)...)
 }
 
 func (r *resourceVolume) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
@@ -358,7 +378,7 @@ func (r *resourceVolume) Update(ctx context.Context, req resource.UpdateRequest,
 		return
 	}
 
-	updateTimeout, diags := planData.Timeouts.Update(ctx, UpdateDefaultTimeout)
+	timeout, diags := planData.Timeouts.Update(ctx, UpdateDefaultTimeout)
 	if fwhelpers.CheckDiags(resp, diags) {
 		return
 	}
@@ -366,7 +386,7 @@ func (r *resourceVolume) Update(ctx context.Context, req resource.UpdateRequest,
 	volumeId := stateData.VolumeId.ValueString()
 	stateData.TerminationSnapshotName = planData.TerminationSnapshotName
 
-	diag := updateOAPITagsFW(ctx, r.Client, updateTimeout, stateData.Tags, planData.Tags, volumeId)
+	diag := updateOAPITagsFW(ctx, r.Client, timeout, stateData.Tags, planData.Tags, volumeId)
 	if fwhelpers.CheckDiags(resp, diag) {
 		return
 	}
@@ -394,38 +414,29 @@ func (r *resourceVolume) Update(ctx context.Context, req resource.UpdateRequest,
 	}
 
 	if shouldUpdate {
-		volume, err := r.Client.UpdateVolume(ctx, updateReq, options.WithRetryTimeout(updateTimeout))
+		volume, err := r.Client.UpdateVolume(ctx, updateReq, options.WithRetryTimeout(timeout))
 		if err != nil {
-			resp.Diagnostics.AddError(
-				"Unable to update volume resource",
-				err.Error(),
-			)
+			resp.Diagnostics.AddError(volumeErrUpdate, err.Error())
 			return
 		}
 
 		if volume.Volume.TaskId != nil {
-			err := WaitForVolumeTasks(ctx, updateTimeout, []string{*volume.Volume.TaskId}, r.Client)
+			err := WaitForVolumeTasks(ctx, timeout, []string{*volume.Volume.TaskId}, r.Client)
 			if err != nil {
-				resp.Diagnostics.AddError(
-					"Error waiting for volume update task to complete",
-					err.Error(),
-				)
+				resp.Diagnostics.AddError(volumeErrTask, err.Error())
 				return
 			}
 		}
 	}
 
 	stateData.Timeouts = planData.Timeouts
-	err := setVolumeState(ctx, r, &stateData)
+	newData, err := r.read(ctx, timeout, stateData)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to set volume state",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &stateData)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &newData)...)
 }
 
 func WaitForVolumeTasks(ctx context.Context, timeout time.Duration, tasksIds []string, client *osc.Client) error {
@@ -476,7 +487,7 @@ func (r *resourceVolume) Delete(ctx context.Context, req resource.DeleteRequest,
 		return
 	}
 
-	deleteTimeout, diags := data.Timeouts.Delete(ctx, DeleteDefaultTimeout)
+	timeout, diags := data.Timeouts.Delete(ctx, DeleteDefaultTimeout)
 	if fwhelpers.CheckDiags(resp, diags) {
 		return
 	}
@@ -488,12 +499,9 @@ func (r *resourceVolume) Delete(ctx context.Context, req resource.DeleteRequest,
 			Description: &description,
 			VolumeId:    &volumeId,
 		}
-		_, err := r.Client.CreateSnapshot(ctx, request, options.WithRetryTimeout(deleteTimeout))
+		_, err := r.Client.CreateSnapshot(ctx, request, options.WithRetryTimeout(timeout))
 		if err != nil {
-			resp.Diagnostics.AddError(
-				fmt.Sprintf("Unable to create snapshot from volume '%s' ", volumeId),
-				err.Error(),
-			)
+			resp.Diagnostics.AddError(volumeErrSnapshot, err.Error())
 			return
 		}
 
@@ -501,12 +509,9 @@ func (r *resourceVolume) Delete(ctx context.Context, req resource.DeleteRequest,
 			Key:   "Name",
 			Value: data.TerminationSnapshotName.String(),
 		}
-		err = createOAPITags(ctx, r.Client, deleteTimeout, []osc.ResourceTag{tags}, snapshotId)
+		err = createOAPITags(ctx, r.Client, timeout, []osc.ResourceTag{tags}, snapshotId)
 		if err != nil {
-			resp.Diagnostics.AddError(
-				fmt.Sprintf("Unable to create tags for snapshot '%s' ", snapshotId),
-				err.Error(),
-			)
+			resp.Diagnostics.AddError(volumeErrTags, err.Error())
 			return
 		}
 	}
@@ -514,40 +519,40 @@ func (r *resourceVolume) Delete(ctx context.Context, req resource.DeleteRequest,
 	delReq := osc.DeleteVolumeRequest{
 		VolumeId: data.VolumeId.ValueString(),
 	}
-	_, err := r.Client.DeleteVolume(ctx, delReq, options.WithRetryTimeout(deleteTimeout))
+	_, err := r.Client.DeleteVolume(ctx, delReq, options.WithRetryTimeout(timeout))
 	if err != nil {
 		resp.Diagnostics.AddError(
-			"Unable to Delete volume",
+			volumeErrDelete,
 			err.Error(),
 		)
 	}
 }
 
-func setVolumeState(ctx context.Context, r *resourceVolume, data *VolumeModel) error {
-	readTimeout, diags := data.Timeouts.Read(ctx, ReadDefaultTimeout)
-	if diags.HasError() {
-		return fmt.Errorf("unable to parse 'volume' read timeout value: %v", diags.Errors())
-	}
-	ctxWithTimeout, cancel := context.WithTimeout(ctx, readTimeout)
+func (r *resourceVolume) read(ctx context.Context, timeout time.Duration, data VolumeModel) (VolumeModel, error) {
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	volume, err := r.Batcher.Read(ctxWithTimeout, data.VolumeId.ValueString())
 	if err != nil {
 		if errors.Is(err, batch.ErrNotFound) {
-			return ErrResourceEmpty
+			return data, ErrResourceEmpty
 		}
-		return err
+		return data, err
 	}
 
+	return r.flatten(ctx, data, *volume)
+}
+
+func (r *resourceVolume) flatten(ctx context.Context, data VolumeModel, volume osc.Volume) (VolumeModel, error) {
 	tags, diag := flattenOAPITagsFW(ctx, volume.Tags)
 	if diag.HasError() {
-		return fmt.Errorf("unable to flatten tags: %v", diags.Errors())
+		return data, from.Diag(diag)
 	}
 	data.Tags = tags
 
-	data.LinkedVolumes, diags = types.SetValueFrom(ctx, types.ObjectType{AttrTypes: fwhelpers.GetAttrTypes(BlockLinkedVolumes{})}, getLinkedVolumesFromApiResponse(volume.LinkedVolumes))
-	if diags.HasError() {
-		return fmt.Errorf("unable to set linkedvolumes block: %v", diags.Errors())
+	data.LinkedVolumes, diag = types.SetValueFrom(ctx, types.ObjectType{AttrTypes: fwhelpers.GetAttrTypes(BlockLinkedVolumes{})}, getLinkedVolumesFromApiResponse(volume.LinkedVolumes))
+	if diag.HasError() {
+		return data, from.Diag(diag)
 	}
 	data.CreationDate = to.String(from.ISO8601(volume.CreationDate))
 	if data.TerminationSnapshotName.IsNull() {
@@ -558,7 +563,7 @@ func setVolumeState(ctx context.Context, r *resourceVolume, data *VolumeModel) e
 	data.VolumeId = to.String(volume.VolumeId)
 	data.SnapshotId = to.String(ptr.From(volume.SnapshotId))
 	data.State = to.String(volume.State)
-	if data.VolumeType.ValueString() != "standard" {
+	if data.VolumeType.ValueString() != string(osc.VolumeTypeStandard) {
 		data.Iops = to.Int32(int32(volume.Iops)) //nolint:gosec
 	} else {
 		data.Iops = types.Int32Null()
@@ -566,7 +571,7 @@ func setVolumeState(ctx context.Context, r *resourceVolume, data *VolumeModel) e
 	data.Size = to.Int32(int32(volume.Size)) //nolint:gosec
 	data.Id = to.String(volume.VolumeId)
 
-	return nil
+	return data, nil
 }
 
 func (r *volumeCommon) stateRefreshFunc(volumeID string) stateconf.StateRefreshFunc[osc.VolumeState] {

--- a/internal/services/oapi/resource_volume_link.go
+++ b/internal/services/oapi/resource_volume_link.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -28,6 +29,16 @@ var (
 	_ resource.ResourceWithConfigure   = &resourceVolumeLink{}
 	_ resource.ResourceWithModifyPlan  = &resourceVolumeLink{}
 	_ resource.ResourceWithImportState = &resourceVolumeLink{}
+)
+
+const (
+	volumeLinkErrVolumeState = "Invalid Volume state to be linked"
+	volumeLinkErrVmState     = "Invalid VM state to be linked"
+	volumeLinkErrCreate      = "Unable to link Volume"
+	volumeLinkErrWait        = "Unable to wait for Volume link state"
+	volumeLinkErrUpdate      = "Unable to set Volume link state after update"
+	volumeLinkErrDelete      = "Unable to unlink Volume"
+	volumeLinkErrUnlinkState = "Invalid unlinked Volume state"
 )
 
 type VolumeLinkModel struct {
@@ -163,7 +174,7 @@ func (r *resourceVolumeLink) Create(ctx context.Context, req resource.CreateRequ
 		return
 	}
 
-	createTimeout, diags := data.Timeouts.Create(ctx, CreateDefaultTimeout)
+	timeout, diags := data.Timeouts.Create(ctx, CreateDefaultTimeout)
 	if fwhelpers.CheckDiags(resp, diags) {
 		return
 	}
@@ -171,12 +182,11 @@ func (r *resourceVolumeLink) Create(ctx context.Context, req resource.CreateRequ
 	volStateConf := &stateconf.StateChangeConf[osc.VolumeState]{
 		Pending: stateconf.States(osc.VolumeStateCreating),
 		Target:  stateconf.States(osc.VolumeStateAvailable),
-		Timeout: createTimeout,
+		Timeout: timeout,
 		Refresh: r.stateRefreshFunc(data.VolumeId.ValueString()),
 	}
 	if _, err := volStateConf.WaitForStateContext(ctx); err != nil {
-		resp.Diagnostics.AddError(
-			"Invalid volume state to be linked",
+		resp.Diagnostics.AddError(volumeLinkErrVolumeState,
 			fmt.Sprintf("Expected state 'available', got: '%s' ", err.Error()),
 		)
 		return
@@ -185,12 +195,11 @@ func (r *resourceVolumeLink) Create(ctx context.Context, req resource.CreateRequ
 	vmStateConf := &stateconf.StateChangeConf[osc.VmState]{
 		Pending: stateconf.States(osc.VmStatePending),
 		Target:  stateconf.States(osc.VmStateRunning, osc.VmStateStopped),
-		Timeout: createTimeout,
+		Timeout: timeout,
 		Refresh: r.vmStateRefreshFunc(data.VmId.ValueString()),
 	}
 	if _, err := vmStateConf.WaitForStateContext(ctx); err != nil {
-		resp.Diagnostics.AddError(
-			"Invalid vm state to be linked",
+		resp.Diagnostics.AddError(volumeLinkErrVmState,
 			fmt.Sprintf("Expected state 'running', got: '%s' ", err.Error()),
 		)
 		return
@@ -201,39 +210,43 @@ func (r *resourceVolumeLink) Create(ctx context.Context, req resource.CreateRequ
 		VmId:       data.VmId.ValueString(),
 		VolumeId:   data.VolumeId.ValueString(),
 	}
-	linkResp, err := r.Client.LinkVolume(ctx, createReq, options.WithRetryTimeout(createTimeout))
+	linkResp, err := r.Client.LinkVolume(ctx, createReq, options.WithRetryTimeout(timeout))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to Link volume resource",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(volumeLinkErrCreate, err.Error())
 		return
 	}
-	data.RequestId = to.String(*linkResp.ResponseContext.RequestId)
+	data.Id = to.String(data.VolumeId.ValueString())
+	data.RequestId = to.String(linkResp.ResponseContext.RequestId)
+
+	// LinkVolume response does not return the volume object, a read is required to store the initial state
+	stateData, err := r.read(ctx, timeout, data)
+	if err != nil {
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
+		return
+	}
+	diags = resp.State.Set(ctx, &stateData)
+	if fwhelpers.CheckDiags(resp, diags) {
+		return
+	}
 
 	linkedStateConf := &stateconf.StateChangeConf[osc.LinkedVolumeState]{
 		Pending: stateconf.States(osc.LinkedVolumeStateAttaching),
 		Target:  stateconf.States(osc.LinkedVolumeStateAttached),
-		Timeout: createTimeout,
-		Refresh: getvolumeAttachmentStateRefreshFunc(r.Client, data.VmId.ValueString(), data.VolumeId.ValueString()),
+		Timeout: timeout,
+		Refresh: r.refreshFunc(data.VmId.ValueString(), data.VolumeId.ValueString()),
 	}
-	if _, err = linkedStateConf.WaitForStateContext(ctx); err != nil {
-		resp.Diagnostics.AddError(
-			"Invalid linked volume state",
+	volumeAny, err := linkedStateConf.WaitForStateContext(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError(volumeLinkErrWait,
 			fmt.Sprintf("Expected state 'attached', got: '%s' ", err.Error()),
 		)
 		return
 	}
+	// We set the last read response to the state
+	volume := volumeAny.(osc.LinkedVolume)
+	stateData = r.flatten(data, volume)
 
-	err = setLinkedVolumeState(ctx, r, &data)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to set volume state",
-			err.Error(),
-		)
-		return
-	}
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateData)...)
 }
 
 func (r *resourceVolumeLink) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -244,42 +257,46 @@ func (r *resourceVolumeLink) Read(ctx context.Context, req resource.ReadRequest,
 		return
 	}
 
-	err := setLinkedVolumeState(ctx, r, &data)
+	timeout, diags := data.Timeouts.Read(ctx, ReadDefaultTimeout)
+	if fwhelpers.CheckDiags(resp, diags) {
+		return
+	}
+
+	stateData, err := r.read(ctx, timeout, data)
 	if err != nil {
 		if errors.Is(err, ErrResourceEmpty) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(
-			"Unable to set volume API response values.",
-			"Error: "+err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateData)...)
 }
 
 func (r *resourceVolumeLink) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var dataPlan, dataState VolumeLinkModel
-
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &dataPlan)...)
 	resp.Diagnostics.Append(req.State.Get(ctx, &dataState)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	dataState.ForceUnlink = dataPlan.ForceUnlink
 
-	dataState.Timeouts = dataPlan.Timeouts
-	err := setLinkedVolumeState(ctx, r, &dataState)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to set volume state after link volume updating.",
-			err.Error(),
-		)
+	timeout, diags := dataPlan.Timeouts.Update(ctx, UpdateDefaultTimeout)
+	if fwhelpers.CheckDiags(resp, diags) {
 		return
 	}
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &dataState)...)
+	dataState.ForceUnlink = dataPlan.ForceUnlink
+	dataState.Timeouts = dataPlan.Timeouts
+
+	newData, err := r.read(ctx, timeout, dataState)
+	if err != nil {
+		resp.Diagnostics.AddError(volumeLinkErrUpdate, err.Error())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &newData)...)
 }
 
 func (r *resourceVolumeLink) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
@@ -290,7 +307,7 @@ func (r *resourceVolumeLink) Delete(ctx context.Context, req resource.DeleteRequ
 		return
 	}
 
-	deleteTimeout, diags := data.Timeouts.Delete(ctx, DeleteDefaultTimeout)
+	timeout, diags := data.Timeouts.Delete(ctx, DeleteDefaultTimeout)
 	if fwhelpers.CheckDiags(resp, diags) {
 		return
 	}
@@ -300,60 +317,62 @@ func (r *resourceVolumeLink) Delete(ctx context.Context, req resource.DeleteRequ
 		ForceUnlink: data.ForceUnlink.ValueBoolPointer(),
 	}
 
-	_, err := r.Client.UnlinkVolume(ctx, delReq, options.WithRetryTimeout(deleteTimeout))
+	_, err := r.Client.UnlinkVolume(ctx, delReq, options.WithRetryTimeout(timeout))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to unlink volume",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError(volumeLinkErrDelete, err.Error())
 		return
 	}
 	unLinkedStateConf := &stateconf.StateChangeConf[osc.LinkedVolumeState]{
 		Pending: stateconf.States(osc.LinkedVolumeStateDetaching),
 		Target:  stateconf.States(osc.LinkedVolumeStateDetached),
-		Timeout: deleteTimeout,
-		Refresh: getvolumeAttachmentStateRefreshFunc(r.Client, data.VmId.ValueString(), data.VolumeId.ValueString()),
+		Timeout: timeout,
+		Refresh: r.refreshFunc(data.VmId.ValueString(), data.VolumeId.ValueString()),
 	}
 	if _, err = unLinkedStateConf.WaitForStateContext(ctx); err != nil {
+		if errors.Is(err, ErrResourceEmpty) {
+			return
+		}
 		resp.Diagnostics.AddError(
-			"Invalid unlinked volume state",
+			volumeLinkErrUnlinkState,
 			fmt.Sprintf("Expected state 'detached', got: '%s' ", err.Error()),
 		)
 		return
 	}
-	resp.State.RemoveResource(ctx)
 }
 
-func setLinkedVolumeState(ctx context.Context, r *resourceVolumeLink, data *VolumeLinkModel) error {
-	readTimeout, diags := data.Timeouts.Read(ctx, ReadDefaultTimeout)
-	if diags.HasError() {
-		return fmt.Errorf("unable to parse 'volume_link' read timeout value: %v", diags.Errors())
-	}
-	ctxWithTimeout, cancel := context.WithTimeout(ctx, readTimeout)
+func (r *resourceVolumeLink) read(ctx context.Context, timeout time.Duration, data VolumeLinkModel) (VolumeLinkModel, error) {
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	vol, err := r.Batcher.Read(ctxWithTimeout, data.VolumeId.ValueString())
 	if err != nil {
 		if errors.Is(err, batch.ErrNotFound) {
-			return ErrResourceEmpty
+			return data, ErrResourceEmpty
 		}
-		return err
+		return data, err
+	}
+	if len(vol.LinkedVolumes) == 0 {
+		return data, ErrResourceEmpty
 	}
 
+	return r.flatten(data, vol.LinkedVolumes[0]), nil
+}
+
+func (r *resourceVolumeLink) flatten(data VolumeLinkModel, volume osc.LinkedVolume) VolumeLinkModel {
 	isForceUnlink := false
-	linkedVol := vol.LinkedVolumes[0]
+
 	if data.ForceUnlink.ValueBool() {
 		isForceUnlink = data.ForceUnlink.ValueBool()
 	}
 	data.ForceUnlink = to.Bool(isForceUnlink)
-	data.DeleteOnVmDeletion = to.Bool(linkedVol.DeleteOnVmDeletion)
-	data.VolumeId = to.String(linkedVol.VolumeId)
-	data.DeviceName = to.String(linkedVol.DeviceName)
-	data.State = to.String(linkedVol.State)
-	data.VmId = to.String(linkedVol.VmId)
-	data.Id = to.String(linkedVol.VolumeId)
+	data.DeleteOnVmDeletion = to.Bool(volume.DeleteOnVmDeletion)
+	data.VolumeId = to.String(volume.VolumeId)
+	data.DeviceName = to.String(volume.DeviceName)
+	data.State = to.String(volume.State)
+	data.VmId = to.String(volume.VmId)
+	data.Id = to.String(volume.VolumeId)
 
-	return nil
+	return data
 }
 
 func (r *resourceVolumeLink) vmStateRefreshFunc(vmId string) stateconf.StateRefreshFunc[osc.VmState] {
@@ -373,7 +392,7 @@ func (r *resourceVolumeLink) vmStateRefreshFunc(vmId string) stateconf.StateRefr
 	}
 }
 
-func getvolumeAttachmentStateRefreshFunc(client *osc.Client, vmId string, volumeId string) stateconf.StateRefreshFunc[osc.LinkedVolumeState] {
+func (r *resourceVolumeLink) refreshFunc(vmId string, volumeId string) stateconf.StateRefreshFunc[osc.LinkedVolumeState] {
 	return func(ctx context.Context) (any, osc.LinkedVolumeState, error) {
 		request := osc.ReadVolumesRequest{
 			Filters: &osc.FiltersVolume{
@@ -382,16 +401,15 @@ func getvolumeAttachmentStateRefreshFunc(client *osc.Client, vmId string, volume
 			},
 		}
 
-		resp, err := client.ReadVolumes(ctx, request)
+		resp, err := r.Client.ReadVolumes(ctx, request)
 		if err != nil {
 			return nil, "", err
 		}
-
-		if len(ptr.From(resp.Volumes)) > 0 && len((*resp.Volumes)[0].LinkedVolumes) > 0 {
-			linkedVolume := (*resp.Volumes)[0].LinkedVolumes[0]
-			return linkedVolume, linkedVolume.State, nil
+		if len(ptr.From(resp.Volumes)) == 0 || len((*resp.Volumes)[0].LinkedVolumes) == 0 {
+			return nil, "", ErrResourceEmpty
 		}
 
-		return resp.Volumes, osc.LinkedVolumeStateDetached, nil
+		volume := (*resp.Volumes)[0]
+		return volume.LinkedVolumes[0], volume.LinkedVolumes[0].State, nil
 	}
 }

--- a/internal/services/oapi/resource_volume_test.go
+++ b/internal/services/oapi/resource_volume_test.go
@@ -2,6 +2,7 @@ package oapi_test
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/outscale/terraform-provider-outscale/internal/testacc"
@@ -128,6 +129,25 @@ func TestAccOthers_Volume_Migration(t *testing.T) {
 	})
 }
 
+func TestAccOthers_Volume_CreateFailureKeepsState(t *testing.T) {
+	resourceName := "outscale_volume.accvolume"
+	region := utils.GetRegion()
+	invalidTagKey := strings.Repeat("a", 256)
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testacc.ProtoV6ProviderFactories(),
+		Steps: testacc.CreateFailureReplacementSteps(
+			resourceName,
+			testAccOutscaleVolumeConfigWithTag(region, invalidTagKey, "testacc-volume"),
+			testAccOutscaleVolumeConfigWithTag(region, "Name", "testacc-volume"),
+			resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttrSet(resourceName, "volume_id"),
+				resource.TestCheckResourceAttr(resourceName, "tags.0.value", "testacc-volume"),
+			),
+		),
+	})
+}
+
 func testAccOutscaleVolumeConfig(region string) string {
 	return fmt.Sprintf(`
 		resource "outscale_volume" "accvolume" {
@@ -136,6 +156,20 @@ func testAccOutscaleVolumeConfig(region string) string {
 			size           = 1
 		}
 	`, region)
+}
+
+func testAccOutscaleVolumeConfigWithTag(region, tagKey, tagValue string) string {
+	return fmt.Sprintf(`
+		resource "outscale_volume" "accvolume" {
+			subregion_name = "%sa"
+			volume_type    = "standard"
+			size           = 1
+			tags {
+				key   = %q
+				value = %q
+			}
+		}
+	`, region, tagKey, tagValue)
 }
 
 func testOutscaleVolumeConfigUpdate(region string) string {

--- a/internal/services/oapi/resource_vpn_connection.go
+++ b/internal/services/oapi/resource_vpn_connection.go
@@ -34,9 +34,7 @@ var (
 
 const (
 	vpnConnectionErrCreate = "Unable to create VPN Connection"
-	vpnConnectionErrRead   = "Unable to read VPN Connection"
 	vpnConnectionErrDelete = "Unable to delete VPN Connection"
-	vpnConnectionErrState  = "Unable to set VPN Connection state"
 	vpnConnectionErrWait   = "Unable to wait for VPN Connection state"
 )
 
@@ -260,19 +258,29 @@ func (r *vpnConnectionResource) Create(ctx context.Context, req resource.CreateR
 		resp.Diagnostics.AddError(vpnConnectionErrCreate, err.Error())
 		return
 	}
+	vpn := createResp.VpnConnection
+	data.RequestId = to.String(createResp.ResponseContext.RequestId)
+	data.Id = to.String(vpn.VpnConnectionId)
+	data.VpnConnectionId = to.String(vpn.VpnConnectionId)
 
-	id := createResp.VpnConnection.VpnConnectionId
-	data.Id = to.String(id)
-	data.VpnConnectionId = to.String(id)
+	stateData, err := r.flatten(ctx, data, vpn)
+	if err != nil {
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
+		return
+	}
+	diags = resp.State.Set(ctx, &stateData)
+	if fwhelpers.CheckDiags(resp, diags) {
+		return
+	}
 
-	diag := createOAPITagsFW(ctx, r.Client, timeout, data.Tags, id)
+	diag := createOAPITagsFW(ctx, r.Client, timeout, data.Tags, vpn.VpnConnectionId)
 	if fwhelpers.CheckDiags(resp, diag) {
 		return
 	}
 
-	stateData, err := r.read(ctx, timeout, data)
+	stateData, err = r.read(ctx, timeout, data)
 	if err != nil {
-		resp.Diagnostics.AddError(vpnConnectionErrRead, err.Error())
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
@@ -294,7 +302,7 @@ func (r *vpnConnectionResource) Read(ctx context.Context, req resource.ReadReque
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(vpnConnectionErrRead, err.Error())
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
@@ -325,7 +333,7 @@ func (r *vpnConnectionResource) Update(ctx context.Context, req resource.UpdateR
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(vpnConnectionErrState, err.Error())
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
@@ -382,10 +390,18 @@ func (r *vpnConnectionResource) read(ctx context.Context, timeout time.Duration,
 	resp := respAny.(*osc.ReadVpnConnectionsResponse)
 	vpn := (*resp.VpnConnections)[0]
 
+	data.RequestId = to.String(resp.ResponseContext.RequestId)
+
 	if vpn.State == osc.VpnConnectionStateDeleted {
 		return data, ErrResourceEmpty
 	}
 
+	data.RequestId = to.String(resp.ResponseContext.RequestId)
+
+	return r.flatten(ctx, data, &vpn)
+}
+
+func (r *vpnConnectionResource) flatten(ctx context.Context, data vpnConnectionModel, vpn *osc.VpnConnection) (vpnConnectionModel, error) {
 	tags, diag := flattenOAPITagsFW(ctx, vpn.Tags)
 	if diag.HasError() {
 		return data, from.Diag(diag)
@@ -410,7 +426,6 @@ func (r *vpnConnectionResource) read(ctx context.Context, timeout time.Duration,
 	data.StaticRoutesOnly = to.Bool(vpn.StaticRoutesOnly)
 	data.VirtualGatewayId = to.String(vpn.VirtualGatewayId)
 	data.ConnectionType = to.String(vpn.ConnectionType)
-	data.RequestId = to.String(resp.ResponseContext.RequestId)
 	data.ClientGatewayId = to.String(vpn.ClientGatewayId)
 	data.Id = to.String(vpn.VpnConnectionId)
 

--- a/internal/services/oapi/resource_vpn_connection_route.go
+++ b/internal/services/oapi/resource_vpn_connection_route.go
@@ -31,7 +31,6 @@ var (
 
 const (
 	vpnConnectionRouteErrCreate = "Unable to create VPN Connection Route"
-	vpnConnectionRouteErrRead   = "Unable to read VPN Connection Route"
 	vpnConnectionRouteErrDelete = "Unable to delete VPN Connection Route"
 	vpnConnectionRouteErrWait   = "Unable to wait for VPN Connection Route state"
 )
@@ -153,17 +152,23 @@ func (r *vpnConnectionRouteResource) Create(ctx context.Context, req resource.Cr
 		DestinationIpRange: data.DestinationIpRange.ValueString(),
 		VpnConnectionId:    data.VpnConnectionId.ValueString(),
 	}
-	_, err := r.Client.CreateVpnConnectionRoute(ctx, createReq, options.WithRetryTimeout(timeout))
+	createResp, err := r.Client.CreateVpnConnectionRoute(ctx, createReq, options.WithRetryTimeout(timeout))
 	if err != nil {
 		resp.Diagnostics.AddError(vpnConnectionRouteErrCreate, err.Error())
 		return
 	}
 
 	data.Id = to.String(fmt.Sprintf("%s:%s", ipRange, vpnId))
+	data.RequestId = to.String(createResp.ResponseContext.RequestId)
+
+	diags = resp.State.Set(ctx, &data)
+	if fwhelpers.CheckDiags(resp, diags) {
+		return
+	}
 
 	stateData, err := r.read(ctx, timeout, data)
 	if err != nil {
-		resp.Diagnostics.AddError(vpnConnectionRouteErrRead, err.Error())
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
@@ -188,7 +193,7 @@ func (r *vpnConnectionRouteResource) Read(ctx context.Context, req resource.Read
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(vpnConnectionRouteErrRead, err.Error())
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 

--- a/internal/services/oapi/resource_vpn_connection_test.go
+++ b/internal/services/oapi/resource_vpn_connection_test.go
@@ -2,6 +2,7 @@ package oapi_test
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/outscale/terraform-provider-outscale/internal/services/oapi/oapihelpers"
@@ -74,7 +75,41 @@ func TestAccOthers_VPNConnection_Migration(t *testing.T) {
 	})
 }
 
+func TestAccOthers_VPNConnection_CreateFailureKeepsState(t *testing.T) {
+	resourceName := "outscale_vpn_connection.vpn_basic"
+	publicIP := fmt.Sprintf("172.0.0.%d", utils.RandIntRange(1, 255))
+	bgpAsn := oapihelpers.RandBgpAsn()
+	invalidTagKey := strings.Repeat("a", 256)
+	tagValue := "testacc-vpn-create-failure"
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testacc.ProtoV6ProviderFactories(),
+		Steps: testacc.CreateFailureReplacementSteps(
+			resourceName,
+			vpnConnectionConfigWithTag(bgpAsn, publicIP, true, invalidTagKey, tagValue),
+			vpnConnectionConfigWithTag(bgpAsn, publicIP, true, "Name", tagValue),
+			resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttrSet(resourceName, "vpn_connection_id"),
+				resource.TestCheckResourceAttr(resourceName, "tags.0.value", tagValue),
+			),
+		),
+	})
+}
+
 func vpnConnectionConfig(bgpAsn int, publicIP string, staticRoutesOnly bool) string {
+	return vpnConnectionConfigWithTag(bgpAsn, publicIP, staticRoutesOnly, "", "")
+}
+
+func vpnConnectionConfigWithTag(bgpAsn int, publicIP string, staticRoutesOnly bool, tagKey, tagValue string) string {
+	tags := ""
+	if tagKey != "" {
+		tags = fmt.Sprintf(`
+			tags {
+				key   = %q
+				value = %q
+			}
+		`, tagKey, tagValue)
+	}
 	return fmt.Sprintf(`
 		resource "outscale_virtual_gateway" "virtual_gateway" {
 			connection_type = "ipsec.1"
@@ -91,8 +126,9 @@ func vpnConnectionConfig(bgpAsn int, publicIP string, staticRoutesOnly bool) str
 			virtual_gateway_id = outscale_virtual_gateway.virtual_gateway.id
 			connection_type    = "ipsec.1"
 			static_routes_only = "%t"
+			%s
 		}
-	`, bgpAsn, publicIP, staticRoutesOnly)
+	`, bgpAsn, publicIP, staticRoutesOnly, tags)
 }
 
 func vpnConnectionConfigWithoutStaticRoutes(bgpAsn int, publicIP string) string {

--- a/internal/services/oks/data_source_oks_kubeconfig.go
+++ b/internal/services/oks/data_source_oks_kubeconfig.go
@@ -19,6 +19,11 @@ var (
 	_ datasource.DataSourceWithConfigure = &oksKubeconfigDataSource{}
 )
 
+const (
+	kubeconfigErrRead  = "Unable to get OKS Kubeconfig"
+	kubeconfigErrParse = "Unable to parse OKS Kubeconfig attributes"
+)
+
 func NewDataSourceOKSKubeconfig() datasource.DataSource {
 	return &oksKubeconfigDataSource{}
 }
@@ -150,10 +155,7 @@ func (d *oksKubeconfigDataSource) Read(ctx context.Context, req datasource.ReadR
 	}
 
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to get OKS Kubeconfig",
-			"Error: "+err.Error(),
-		)
+		resp.Diagnostics.AddError(kubeconfigErrRead, err.Error())
 		return
 	}
 
@@ -161,7 +163,7 @@ func (d *oksKubeconfigDataSource) Read(ctx context.Context, req datasource.ReadR
 
 	kubeconfigAttr, err := parseKubeconfigAttr(ctx, kubeconfigResp.Cluster.Data.Kubeconfig)
 	if err != nil {
-		resp.Diagnostics.AddError("Unable to parse OKS Kubeconfig attributes", "Error: "+err.Error())
+		resp.Diagnostics.AddError(kubeconfigErrParse, err.Error())
 		return
 	}
 	data.KubeconfigAttr = kubeconfigAttr

--- a/internal/services/oks/data_source_oks_quotas.go
+++ b/internal/services/oks/data_source_oks_quotas.go
@@ -18,6 +18,10 @@ var (
 	_ datasource.DataSourceWithConfigure = &oksQuotasDataSource{}
 )
 
+const (
+	quotasErrRead = "Unable to get OKS Quotas"
+)
+
 func NewDataSourceOKSQuotas() datasource.DataSource {
 	return &oksQuotasDataSource{}
 }
@@ -86,10 +90,7 @@ func (d *oksQuotasDataSource) Read(ctx context.Context, req datasource.ReadReque
 
 	quotas, err := d.Client.GetQuotas(ctx)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to get OKS Quotas",
-			"Error: "+err.Error(),
-		)
+		resp.Diagnostics.AddError(quotasErrRead, err.Error())
 		return
 	}
 

--- a/internal/services/oks/errors.go
+++ b/internal/services/oks/errors.go
@@ -2,4 +2,8 @@ package oks
 
 import "errors"
 
+// Resource errors
 var ErrResourceEmpty = errors.New("empty")
+
+// Global errors
+const errSetTerraformState = "Unable to reconcile Terraform state from API response"

--- a/internal/services/oks/resource_oks_cluster.go
+++ b/internal/services/oks/resource_oks_cluster.go
@@ -44,6 +44,14 @@ var (
 	_ resource.ResourceWithModifyPlan  = &oksClusterResource{}
 )
 
+const (
+	clusterErrCreate  = "Unable to create Cluster"
+	clusterErrUpdate  = "Unable to update Cluster"
+	clusterErrDelete  = "Unable to delete Cluster"
+	clusterErrWait    = "Unable to wait for Cluster state"
+	clusterErrUpgrade = "Unable to upgrade Cluster"
+)
+
 type ClusterModel struct {
 	AdminLbu              types.Bool     `tfsdk:"admin_lbu"`
 	AdminWhitelist        types.Set      `tfsdk:"admin_whitelist"`
@@ -574,21 +582,17 @@ func (r *oksClusterResource) Create(ctx context.Context, req resource.CreateRequ
 	}
 	createResp, err := r.Client.CreateCluster(ctx, input, options.WithRetryTimeout(timeout))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to Create Cluster",
-			"Error: "+err.Error(),
-		)
+		resp.Diagnostics.AddError(clusterErrCreate, err.Error())
 		return
 	}
 	plan.RequestId = to.String(createResp.ResponseContext.RequestId)
 	plan.Id = to.String(createResp.Cluster.Id)
+	// The API response does not contain enough information to set the state directly, which would cause an error.
+	// The next read will fill the state
 
 	data, err := r.read(ctx, plan, timeout)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to set Cluster state",
-			"Error: "+err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 	diag = resp.State.Set(ctx, &data)
@@ -612,10 +616,7 @@ func (r *oksClusterResource) Read(ctx context.Context, req resource.ReadRequest,
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(
-			"Unable to set Cluster state",
-			"Error: "+err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 	diag = resp.State.Set(ctx, &data)
@@ -645,10 +646,7 @@ func (r *oksClusterResource) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 	if statuses.Status.ValueString() == "deleting" {
-		resp.Diagnostics.AddError(
-			"Unable to Update Cluster",
-			"Cluster is currently being deleted and cannot be updated. The resource will be removed from the state once deleted.",
-		)
+		resp.Diagnostics.AddError(clusterErrUpdate, "Cluster is currently being deleted and cannot be updated. The resource will be removed from the state once deleted.")
 		return
 	}
 
@@ -757,10 +755,7 @@ func (r *oksClusterResource) Update(ctx context.Context, req resource.UpdateRequ
 	if updateReq != (oks.ClusterUpdate{}) {
 		updateResp, err := r.Client.UpdateCluster(ctx, state.Id.ValueString(), updateReq, options.WithRetryTimeout(timeout))
 		if err != nil {
-			resp.Diagnostics.AddError(
-				"Unable to Update Cluster",
-				"Error: "+err.Error(),
-			)
+			resp.Diagnostics.AddError(clusterErrUpdate, err.Error())
 			return
 		}
 		state.RequestId = to.String(updateResp.ResponseContext.RequestId)
@@ -769,9 +764,7 @@ func (r *oksClusterResource) Update(ctx context.Context, req resource.UpdateRequ
 	if doUpgrade {
 		_, err := r.waitForClusterState(ctx, state.Id.ValueString(), []string{"pending", "updating"}, []string{"ready"}, timeout)
 		if err != nil {
-			resp.Diagnostics.AddError(
-				"Unable to wait for Cluster to complete updating.", "Error: "+err.Error(),
-			)
+			resp.Diagnostics.AddError(clusterErrWait, err.Error())
 			return
 		}
 
@@ -784,10 +777,7 @@ func (r *oksClusterResource) Update(ctx context.Context, req resource.UpdateRequ
 
 		upgradeResp, err := r.Client.UpgradeCluster(ctx, state.Id.ValueString(), options.WithRetryTimeout(upgradeTimeout))
 		if err != nil {
-			resp.Diagnostics.AddError(
-				"Unable to Upgrade Cluster",
-				"Error: "+err.Error(),
-			)
+			resp.Diagnostics.AddError(clusterErrUpgrade, err.Error())
 			return
 		}
 		state.RequestId = to.String(upgradeResp.ResponseContext.RequestId)
@@ -796,10 +786,7 @@ func (r *oksClusterResource) Update(ctx context.Context, req resource.UpdateRequ
 
 	data, err := r.read(ctx, state, timeout)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to set Cluster state",
-			"Error: "+err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 	diag = resp.State.Set(ctx, &data)
@@ -820,17 +807,14 @@ func (r *oksClusterResource) Delete(ctx context.Context, req resource.DeleteRequ
 
 	_, err := r.Client.DeleteCluster(ctx, data.Id.ValueString(), options.WithRetryTimeout(timeout))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to Delete Cluster",
-			"Error: "+err.Error(),
-		)
+		resp.Diagnostics.AddError(clusterErrDelete, err.Error())
 		return
 	}
 
 	_, err = r.waitForClusterState(ctx, data.Id.ValueString(), []string{"pending", "deleting"}, []string{}, timeout)
 	if err != nil {
 		if !oks.IsNotFound(err) {
-			resp.Diagnostics.AddError("Unable to wait for Cluster complete deletion.", "Error: "+err.Error())
+			resp.Diagnostics.AddError(clusterErrWait, err.Error())
 		}
 	}
 }
@@ -1025,23 +1009,23 @@ func (r *oksClusterResource) read(ctx context.Context, data ClusterModel, timeou
 
 	adminWhiteList, diags := types.SetValueFrom(ctx, types.StringType, cluster.AdminWhitelist)
 	if diags.HasError() {
-		return data, fmt.Errorf("unable to convert adminwhitelist into a set: %v", diags.Errors())
+		return data, from.Diag(diags)
 	}
 	cpSubregions, diags := types.SetValueFrom(ctx, types.StringType, cluster.CpSubregions)
 	if diags.HasError() {
-		return data, fmt.Errorf("unable to convert cpsubregions into a set: %v", diags.Errors())
+		return data, from.Diag(diags)
 	}
 	diags = r.setOKSAdmissionFlags(ctx, &data, &cluster.AdmissionFlags)
 	if diags.HasError() {
-		return data, fmt.Errorf("unable to convert admissionflags into the schema model: %v", diags.Errors())
+		return data, from.Diag(diags)
 	}
 	diags = r.setOKSAutoMaintenances(ctx, &data, ptr.From(cluster.AutoMaintenances))
 	if diags.HasError() {
-		return data, fmt.Errorf("unable to convert automaintenances into the schema model: %v", diags.Errors())
+		return data, from.Diag(diags)
 	}
 	diags = r.setOKSStatuses(ctx, &data, cluster.Statuses)
 	if diags.HasError() {
-		return data, fmt.Errorf("unable to convert statuses into the schema model: %v", diags.Errors())
+		return data, from.Diag(diags)
 	}
 
 	data.AdminLbu = to.Bool(cluster.AdminLbu)
@@ -1075,7 +1059,7 @@ func (r *oksClusterResource) read(ctx context.Context, data ClusterModel, timeou
 
 	tags, diags := flattenOKSTags(ctx, cluster.Tags)
 	if diags.HasError() {
-		return data, fmt.Errorf("%v", diags.Errors())
+		return data, from.Diag(diags)
 	}
 	data.Tags = tags
 

--- a/internal/services/oks/resource_oks_manifest.go
+++ b/internal/services/oks/resource_oks_manifest.go
@@ -45,12 +45,12 @@ var (
 )
 
 const (
-	manifestErrCreate    = "Unable to create manifest resource"
-	manifestErrRead      = "Unable to read manifest resource"
-	manifestErrUpdate    = "Unable to update manifest resource"
-	manifestErrDelete    = "Unable to delete manifest resource"
-	manifestErrWait      = "Unable to wait for resource deletion"
-	manifestErrWaitFor   = "Unable to wait for resource wait_for condition to be met"
+	manifestErrCreate  = "Unable to create manifest resource"
+	manifestErrUpdate  = "Unable to update manifest resource"
+	manifestErrDelete  = "Unable to delete manifest resource"
+	manifestErrWait    = "Unable to wait for resource deletion"
+	manifestErrWaitFor = "Unable to wait for resource wait_for condition to be met"
+
 	manifestFieldManager = "terraform-provider-outscale"
 
 	manifestDeleteBlockedWarning = `Terraform is planning to delete this Kubernetes object. The Kubernetes API may reject the deletion if the object is still required by the cluster, for example when deleting the last remaining NodePool.
@@ -289,19 +289,30 @@ func (r *manifestResource) Create(ctx context.Context, req resource.CreateReques
 		return
 	}
 
-	err = r.applyManifest(ctx, &data, obj, dri)
+	respObj, err := r.applyManifest(ctx, &data, obj, dri)
 	if err != nil {
 		resp.Diagnostics.AddError(manifestErrCreate, err.Error())
 		return
 	}
+
+	stateData, err := r.flatten(data, respObj)
+	if err != nil {
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
+		return
+	}
+	diag = resp.State.Set(ctx, &stateData)
+	if fwhelpers.CheckDiags(resp, diag) {
+		return
+	}
+
 	diag = r.waitForFields(ctx, data, obj, dri, timeout)
 	if fwhelpers.CheckDiags(resp, diag) {
 		return
 	}
 
-	stateData, err := r.read(ctx, data, obj, dri)
+	stateData, err = r.read(ctx, data, obj, dri)
 	if err != nil {
-		resp.Diagnostics.AddError(manifestErrRead, err.Error())
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
@@ -322,7 +333,7 @@ func (r *manifestResource) Read(ctx context.Context, req resource.ReadRequest, r
 
 	obj, dri, err := okshelpers.GetResourceInterfaceFromManifest(ctx, r.Client, data.ClusterId.ValueString(), data.Manifest.ValueString(), timeout)
 	if err != nil {
-		resp.Diagnostics.AddError(manifestErrRead, err.Error())
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
@@ -332,7 +343,7 @@ func (r *manifestResource) Read(ctx context.Context, req resource.ReadRequest, r
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(manifestErrRead, err.Error())
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
@@ -359,7 +370,7 @@ func (r *manifestResource) Update(ctx context.Context, req resource.UpdateReques
 	}
 
 	if fwhelpers.HasChange(plan.Manifest, state.Manifest) {
-		err := r.applyManifest(ctx, &plan, obj, dri)
+		_, err := r.applyManifest(ctx, &plan, obj, dri)
 		if err != nil {
 			resp.Diagnostics.AddError(manifestErrUpdate, err.Error())
 			return
@@ -373,7 +384,7 @@ func (r *manifestResource) Update(ctx context.Context, req resource.UpdateReques
 
 	stateData, err := r.read(ctx, plan, obj, dri)
 	if err != nil {
-		resp.Diagnostics.AddError(manifestErrRead, err.Error())
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
@@ -433,32 +444,36 @@ func (r *manifestResource) read(ctx context.Context, data manifestModel, obj *un
 		return data, fmt.Errorf("get manifest: %w", err)
 	}
 
-	yamlObj, err := okshelpers.ToYAML(respManifest.Object)
+	return r.flatten(data, respManifest)
+}
+
+func (r *manifestResource) flatten(data manifestModel, obj *unstructured.Unstructured) (manifestModel, error) {
+	yamlObj, err := okshelpers.ToYAML(obj.Object)
 	if err != nil {
 		return data, err
 	}
 
-	data.Id = to.String(respManifest.GetUID())
+	data.Id = to.String(obj.GetUID())
 	data.Object = to.String(yamlObj)
 
 	return data, nil
 }
 
-func (r *manifestResource) applyManifest(ctx context.Context, data *manifestModel, obj *unstructured.Unstructured, dri dynamic.ResourceInterface) error {
+func (r *manifestResource) applyManifest(ctx context.Context, data *manifestModel, obj *unstructured.Unstructured, dri dynamic.ResourceInterface) (*unstructured.Unstructured, error) {
 	jsonBytes, err := obj.MarshalJSON()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	patchOptions := metav1.PatchOptions{FieldManager: manifestFieldManager}
 	resp, err := dri.Patch(ctx, obj.GetName(), k8stypes.ApplyPatchType, jsonBytes, patchOptions)
 	if err != nil {
-		return fmt.Errorf("apply manifest: %w", err)
+		return nil, fmt.Errorf("apply manifest: %w", err)
 	}
 
 	data.Id = to.String(resp.GetUID())
 
-	return nil
+	return resp, nil
 }
 
 type fieldMatcher struct {

--- a/internal/services/oks/resource_oks_project.go
+++ b/internal/services/oks/resource_oks_project.go
@@ -31,6 +31,13 @@ var (
 	_ resource.ResourceWithConfigure = &oksProjectResource{}
 )
 
+const (
+	projectErrCreate = "Unable to create OKS Project"
+	projectErrUpdate = "Unable to update OKS Project"
+	projectErrDelete = "Unable to delete OKS Project"
+	projectErrWait   = "Unable to wait for OKS Project state"
+)
+
 type ProjectModel struct {
 	Cidr                  types.String      `tfsdk:"cidr"`
 	CreatedAt             timetypes.RFC3339 `tfsdk:"created_at"`
@@ -198,21 +205,26 @@ func (r *oksProjectResource) Create(ctx context.Context, req resource.CreateRequ
 
 	createResp, err := r.Client.CreateProject(ctx, input, options.WithRetryTimeout(timeout))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to Create Resource Project",
-			"Error: "+err.Error(),
-		)
+		resp.Diagnostics.AddError(projectErrCreate, err.Error())
 		return
 	}
 	data.RequestId = to.String(createResp.ResponseContext.RequestId)
 	data.Id = to.String(createResp.Project.Id)
 
+	stateData, err := r.flatten(ctx, data, createResp.Project)
+	if err != nil {
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
+		return
+	}
+	diags = resp.State.Set(ctx, &stateData)
+	if fwhelpers.CheckDiags(resp, diags) {
+		return
+	}
+
+	// A read call is necessary after the flatten as it waits for the project to be ready
 	data, err = r.read(ctx, data, timeout)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to set Project state",
-			"Error: "+err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
@@ -238,10 +250,7 @@ func (r *oksProjectResource) Read(ctx context.Context, req resource.ReadRequest,
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(
-			"Unable to set Project state",
-			"Error: "+err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 	diags = resp.State.Set(ctx, &data)
@@ -267,7 +276,7 @@ func (r *oksProjectResource) Update(ctx context.Context, req resource.UpdateRequ
 
 	if state.Status.ValueString() == "deleting" {
 		resp.Diagnostics.AddError(
-			"Unable to Update Project",
+			projectErrUpdate,
 			"Project is currently being deleted and cannot be updated. The resource will be removed from the state once deleted.",
 		)
 		return
@@ -295,6 +304,7 @@ func (r *oksProjectResource) Update(ctx context.Context, req resource.UpdateRequ
 	if update != (oks.ProjectUpdate{}) {
 		updateResp, err := r.Client.UpdateProject(ctx, state.Id.ValueString(), update, options.WithRetryTimeout(timeout))
 		if err != nil {
+			resp.Diagnostics.AddError(projectErrUpdate, err.Error())
 			return
 		}
 
@@ -306,10 +316,7 @@ func (r *oksProjectResource) Update(ctx context.Context, req resource.UpdateRequ
 
 	data, err := r.read(ctx, state, timeout)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to set Project state",
-			"Error: "+err.Error(),
-		)
+		resp.Diagnostics.AddError(errSetTerraformState, err.Error())
 		return
 	}
 
@@ -332,17 +339,14 @@ func (r *oksProjectResource) Delete(ctx context.Context, req resource.DeleteRequ
 
 	_, err := r.Client.DeleteProject(ctx, data.Id.ValueString(), options.WithRetryTimeout(timeout))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to Delete Resource Project",
-			"Error: "+err.Error(),
-		)
+		resp.Diagnostics.AddError(projectErrDelete, err.Error())
 		return
 	}
 
 	_, err = r.waitForProjectState(ctx, data.Id.ValueString(), stateconf.States(oks.ProjectStatusDeleting), []oks.ProjectStatus{}, timeout)
 	if err != nil {
 		if !oks.IsNotFound(err) {
-			resp.Diagnostics.AddError("Unable to wait for Project complete deletion.", "Error: "+err.Error())
+			resp.Diagnostics.AddError(projectErrWait, err.Error())
 		}
 	}
 }
@@ -373,8 +377,13 @@ func (r *oksProjectResource) read(ctx context.Context, data ProjectModel, timeou
 	if err != nil {
 		return data, err
 	}
-	project := resp.Project
 
+	data.RequestId = to.String(resp.ResponseContext.RequestId)
+
+	return r.flatten(ctx, data, resp.Project)
+}
+
+func (r *oksProjectResource) flatten(ctx context.Context, data ProjectModel, project oks.Project) (ProjectModel, error) {
 	data.Cidr = to.String(project.Cidr)
 	data.CreatedAt = to.RFC3339(project.CreatedAt)
 	data.Description = to.String(project.Description)
@@ -384,7 +393,6 @@ func (r *oksProjectResource) read(ctx context.Context, data ProjectModel, timeou
 	data.Status = to.String(project.Status)
 	data.UpdatedAt = to.RFC3339(project.UpdatedAt)
 	data.Id = to.String(project.Id)
-	data.RequestId = to.String(resp.ResponseContext.RequestId)
 
 	tags, diags := flattenOKSTags(ctx, project.Tags)
 	if diags.HasError() {

--- a/internal/testacc/testacc.go
+++ b/internal/testacc/testacc.go
@@ -3,6 +3,7 @@ package testacc
 import (
 	"context"
 	"fmt"
+	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
@@ -27,6 +28,8 @@ var (
 	SDKProviders = map[string]*schema.Provider{
 		"outscale": SDKProvider,
 	}
+
+	anyRegexp = regexp.MustCompile(`(?s).+`)
 )
 
 // Returns a map of provider factories for testing with protocol v6
@@ -179,5 +182,29 @@ func importStep(resourceName string, importStateIdFunc resource.ImportStateIdFun
 func DefaultIgnores() []string {
 	return []string{
 		"request_id",
+	}
+}
+
+// CreateFailureReplacementSteps verifies that a create operation failure leaves a tainted resource in state, which Terraform then plans to replace on the next apply
+func CreateFailureReplacementSteps(resourceName, failingConfig string, workingConfig string, check resource.TestCheckFunc) []resource.TestStep {
+	return []resource.TestStep{
+		{
+			Config:      failingConfig,
+			ExpectError: anyRegexp, // expect any error during the failing create
+		},
+		{
+			RefreshState:       true,
+			ExpectNonEmptyPlan: true,
+			RefreshPlanChecks: resource.RefreshPlanChecks{
+				PostRefresh: []plancheck.PlanCheck{
+					// a tainted resource is planned for replacement on the next plan
+					plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionReplace),
+				},
+			},
+		},
+		{
+			Config: workingConfig,
+			Check:  check,
+		},
 	}
 }

--- a/tests/data/oapi/nets/TF-125_security_group_datasource_attributes_ok/step1.security_group_datasource_std_ok.tf
+++ b/tests/data/oapi/nets/TF-125_security_group_datasource_attributes_ok/step1.security_group_datasource_std_ok.tf
@@ -49,6 +49,10 @@ data "outscale_security_group" "outscale_security_groupd" {
 
 data "outscale_security_group" "filters-inbound" {
   filter {
+    name   = "security_group_ids"
+    values = [outscale_security_group.outscale_security_group.security_group_id]
+  }
+  filter {
     name   = "inbound_rule_from_port_ranges"
     values = [80]
   }
@@ -68,6 +72,10 @@ data "outscale_security_group" "filters-inbound" {
 }
 
 data "outscale_security_group" "filters-tags" {
+  filter {
+    name   = "security_group_ids"
+    values = [outscale_security_group.outscale_security_group.security_group_id]
+  }
   filter {
     name   = "tag_keys"
     values = ["Key:"]

--- a/tests/data/oapi/nets/TF-125_security_group_datasource_attributes_ok/step2.security_group_datasource_ok.tf
+++ b/tests/data/oapi/nets/TF-125_security_group_datasource_attributes_ok/step2.security_group_datasource_ok.tf
@@ -45,6 +45,10 @@ resource "outscale_security_group_rule" "outscale_security_group_rule-2" {
 
 data "outscale_security_group" "filters-outbound" {
   filter {
+    name   = "security_group_ids"
+    values = [outscale_security_group.outscale_security_group.security_group_id]
+  }
+  filter {
     name   = "net_ids"
     values = [outscale_net.outscale_net.net_id]
   }

--- a/tests/data/oapi/nets/TF-125_security_group_datasource_attributes_ok/step3.security_group_datasource_ok.tf
+++ b/tests/data/oapi/nets/TF-125_security_group_datasource_attributes_ok/step3.security_group_datasource_ok.tf
@@ -44,6 +44,10 @@ resource "outscale_security_group_rule" "outscale_security_group_rule-3" {
 
 data "outscale_security_group" "filters-inbound" {
   filter {
+    name   = "security_group_ids"
+    values = [outscale_security_group.outscale_security_group.security_group_id]
+  }
+  filter {
     name   = "inbound_rule_from_port_ranges"
     values = ["22"]
   }

--- a/tests/data/oapi/nets/TF-125_security_group_datasource_attributes_ok/step4.security_group_datasource_ok.tf
+++ b/tests/data/oapi/nets/TF-125_security_group_datasource_attributes_ok/step4.security_group_datasource_ok.tf
@@ -45,6 +45,10 @@ resource "outscale_security_group_rule" "outscale_security_group_rule-3_2" {
 
 data "outscale_security_group" "filters-outbound" {
   filter {
+    name   = "security_group_ids"
+    values = [outscale_security_group.outscale_security_group.security_group_id]
+  }
+  filter {
     name   = "net_ids"
     values = [outscale_net.outscale_net.net_id]
   }


### PR DESCRIPTION
## Description

This PR fixes a provider-wide issue where resources that return an error during the Create process (because of timeout, a tag creation failure, or any other post-creation API call) would not be stored in state, which led to untracked dead resources.

Because of the Terraform Plugin Framework design, any error returned during the Create phase will cause the state to be tainted, and will make any following terraform plan/apply call recreate the resource. This is not perfect but allows the resource to be tracked and destroyed by the provider.

A user could theoretically untaint the resource stored in state to perform an apply and not have to destroy the created resource. This has not been tested and we cannot guarantee that it will not cause any errors.

Fixes: #751

## Type of Change

Please check the relevant option(s):

- [X] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [X] Manual testing
- [ ] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [X] I have followed the [Contributing Guidelines](CONTRIBUTING.md)
* [X] I have added tests or explained why they are not needed
* [X] I have updated relevant documentation (README, examples, etc.)
* [X] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [X] My commits include appropriate [Gitmoji](https://gitmoji.dev/)