### PR TITLE
🚸 chore(fgpu_link): show warning about vm start/stop

### DIFF
--- a/internal/services/oapi/resource_flexible_gpu_link.go
+++ b/internal/services/oapi/resource_flexible_gpu_link.go
@@ -27,8 +27,9 @@ import (
 )
 
 var (
-	_ resource.Resource              = &fgpuLinkResource{}
-	_ resource.ResourceWithConfigure = &fgpuLinkResource{}
+	_ resource.Resource               = &fgpuLinkResource{}
+	_ resource.ResourceWithConfigure  = &fgpuLinkResource{}
+	_ resource.ResourceWithModifyPlan = &fgpuLinkResource{}
 )
 
 const (
@@ -99,6 +100,72 @@ func (r *fgpuLinkResource) ImportState(ctx context.Context, req resource.ImportS
 
 func (r *fgpuLinkResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_flexible_gpu_link"
+}
+
+func (r *fgpuLinkResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	// destroy: no-op
+	if req.Plan.Raw.IsNull() {
+		return
+	}
+
+	var planData fgpuLinkModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &planData)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if req.State.Raw.IsNull() {
+		// When vm_id comes from a resource being created in the same apply, the restart warning is not useful
+		if !fwhelpers.IsSet(planData.VmId) || planData.VmId.ValueString() == "" || !fwhelpers.IsSet(planData.Id) {
+			return
+		}
+
+		resp.Diagnostics.AddWarning(
+			"Flexible GPU link creation restarts the VM",
+			fmt.Sprintf("Creating this resource links the Flexible GPUs to VM %q and the provider will stop then restart the VM during apply.", planData.VmId.ValueString()),
+		)
+		return
+	}
+
+	var stateData, configData fgpuLinkModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &stateData)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(req.Config.Get(ctx, &configData)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	duplicateMessage := "\n\n(This warning is expected to appear twice: during `terraform plan` and again after a successful `terraform apply`. The VMs should be running once apply completes.)"
+
+	if !planData.VmId.Equal(stateData.VmId) {
+		detail := "Replacing this resource unlinks the Flexible GPUs from the current VM and links them to the new VM. The provider will stop and then restart the affected VMs during apply."
+		if fwhelpers.IsSet(stateData.VmId) && fwhelpers.IsSet(planData.VmId) {
+			detail = fmt.Sprintf("Replacing this resource unlinks the Flexible GPUs from VM %q and links them to VM %q. The provider will stop and then restart the affected VMs during apply.", stateData.VmId.ValueString(), planData.VmId.ValueString())
+		}
+		detail += duplicateMessage
+
+		resp.Diagnostics.AddWarning(
+			"Flexible GPU link replacement restarts VMs",
+			detail,
+		)
+
+		return
+	}
+
+	if !planData.FlexibleGpuIds.Equal(stateData.FlexibleGpuIds) {
+		detail := "Updating this resource changes the Flexible GPUs linked to the VM, and the provider will stop and then restart the VM during apply."
+		if fwhelpers.IsSet(planData.VmId) {
+			detail = fmt.Sprintf("Updating this resource changes the Flexible GPUs linked to VM %q, and the provider will stop and then restart the VM during apply.", planData.VmId.ValueString())
+		}
+		detail += duplicateMessage
+
+		resp.Diagnostics.AddWarning(
+			"Flexible GPU link update restarts the VM",
+			detail,
+		)
+	}
 }
 
 func (r *fgpuLinkResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {

--- a/internal/services/oapi/resource_outscale_vm.go
+++ b/internal/services/oapi/resource_outscale_vm.go
@@ -42,9 +42,6 @@ func ResourceOutscaleVM() *schema.Resource {
 			Delete: schema.DefaultTimeout(DeleteDefaultTimeout),
 		},
 		// Schema: //omitted for brevity
-		ValidateRawResourceConfigFuncs: []schema.ValidateRawResourceConfigFunc{
-			validation.PreferWriteOnlyAttribute(cty.GetAttrPath("keypair_name"), cty.GetAttrPath("keypair_name_wo")),
-		},
 		Schema: map[string]*schema.Schema{
 			"actions_on_next_boot": {
 				Type:     schema.TypeList,
@@ -761,11 +758,13 @@ func ResourceOutscaleVM() *schema.Resource {
 
 func resourceOAPIVMCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*client.OutscaleClient).OSC
+	var diags diag.Diagnostics
 
 	vmOpts, bsuMapsTags, err := buildCreateVmsRequest(d)
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	diags = append(diags, keypairWriteOnlyWarning(d)...)
 	vState := d.Get("state").(string)
 	if vState != "stopped" && vState != "running" {
 		return diag.Errorf("error: state must be `stopped or running`")
@@ -853,7 +852,32 @@ func resourceOAPIVMCreate(ctx context.Context, d *schema.ResourceData, meta any)
 		}
 	}
 
-	return resourceOAPIVMRead(ctx, d, meta)
+	diags = append(diags, resourceOAPIVMRead(ctx, d, meta)...)
+	return diags
+}
+
+func keypairWriteOnlyWarning(d *schema.ResourceData) diag.Diagnostics {
+	keypairName, diags := d.GetRawConfigAt(cty.GetAttrPath("keypair_name"))
+	if diags.HasError() {
+		return nil
+	}
+	if keypairName.IsNull() || keypairName.AsString() == "" {
+		return nil
+	}
+
+	keypairNameWO, diags := d.GetRawConfigAt(cty.GetAttrPath("keypair_name_wo"))
+	if diags.HasError() {
+		return nil
+	}
+	if !keypairNameWO.IsNull() && keypairNameWO.AsString() != "" {
+		return nil
+	}
+
+	return diag.Diagnostics{{
+		Severity: diag.Warning,
+		Summary:  "Write-only Alternative Available",
+		Detail:   "The attribute keypair_name has a write-only alternative keypair_name_wo available. Use the write-only alternative when possible to avoid persisting the value in plan and state.",
+	}}
 }
 
 func createBsuTags(ctx context.Context, client *osc.Client, timeout time.Duration, vm osc.Vm, bsuMapsTags []map[string]any) error {


### PR DESCRIPTION
## Description

- **🚸 chore(vm): show keypair_wo warning only during create**
- **🚸 chore(fgpu_link): add warning about vm start/stop**

This issue partially fixes issue #21 by adding warnings during `terraform plan` about VM start/stop. It should also be added to the VM resource but it is currently not possible until the resource is migrated to the Plugin Framework (a new issue has been created to track it #774).

Fixes: #21

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [X] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [ ] Manual testing
- [ ] Unit tests
- [ ] Integration tests
- [X] Not tested yet

## Checklist

* [X] I have followed the [Contributing Guidelines](CONTRIBUTING.md)
* [X] I have added tests or explained why they are not needed
* [X] I have updated relevant documentation (README, examples, etc.)
* [X] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [X] My commits include appropriate [Gitmoji](https://gitmoji.dev/)
