### PR TITLE
🐛 fix(internet_service_link): retry on conflict when NATs are still "linked"

### DIFF
--- a/internal/services/oapi/resource_internet_service_link.go
+++ b/internal/services/oapi/resource_internet_service_link.go
@@ -32,11 +32,12 @@ var (
 )
 
 const (
-	internetServiceLinkErrCreate    = "Unable to link Internet Service"
-	internetServiceLinkErrDelete    = "Unable to unlink Internet Service"
-	internetServiceLinkErrReadNics  = "Unable to read NICs linked to Internet Service net"
-	internetServiceLinkErrUnmapIPs  = "Unable to unlink Public IPs from Internet Service net NICs"
-	internetServiceLinkErrRetryLink = "Unable to unlink Internet Service after unmapping Public IPs"
+	internetServiceLinkErrCreate     = "Unable to link Internet Service"
+	internetServiceLinkErrDelete     = "Unable to unlink Internet Service"
+	internetServiceLinkErrDeleteNats = "Unable to unlink Internet Service. One or more active NATs are still dependent on the Internet Service net"
+	internetServiceLinkErrReadNics   = "Unable to read NICs linked to Internet Service net"
+	internetServiceLinkErrUnmapIPs   = "Unable to unlink Public IPs from Internet Service net NICs"
+	internetServiceLinkErrRetryLink  = "Unable to unlink Internet Service after unmapping Public IPs"
 )
 
 type InternetServiceLinkModel struct {
@@ -235,10 +236,10 @@ func (r *resourceInternetServiceLink) Delete(ctx context.Context, req resource.D
 		NetId:             data.NetId.ValueString(),
 	}
 
-	var hasIPs, hasLBU bool
-	_, err := r.Client.UnlinkInternetService(ctx, unlinkReq, options.WithRetryTimeout(timeout))
-	if err != nil {
-		oscErr := oapihelpers.GetError(err)
+	var hasIPs, hasLBU, hasNAT bool
+	_, unlinkErr := r.Client.UnlinkInternetService(ctx, unlinkReq, options.WithRetryTimeout(timeout))
+	if unlinkErr != nil {
+		oscErr := oapihelpers.GetError(unlinkErr)
 		switch oscErr.Code {
 		case "1004":
 			// 409 with code 1004 is returned when the Net of the Internet Service has mapped Public IPs
@@ -247,8 +248,11 @@ func (r *resourceInternetServiceLink) Delete(ctx context.Context, req resource.D
 		case "1005":
 			// 409 with code 1005 is returned when the Net of the Internet Service has a Load Balancer
 			hasLBU = true
+		case "1018":
+			// 409 with code 1018 is returned when the Net of the Internet Service has a NAT
+			hasNAT = true
 		default:
-			resp.Diagnostics.AddError(internetServiceLinkErrDelete, err.Error())
+			resp.Diagnostics.AddError(internetServiceLinkErrDelete, unlinkErr.Error())
 			return
 		}
 	}
@@ -298,13 +302,17 @@ func (r *resourceInternetServiceLink) Delete(ctx context.Context, req resource.D
 		}
 	}
 
-	if hasLBU {
+	if hasLBU || hasNAT {
 		// We retry on the 1005 error rather than reading the LBU state to decide.
 		// During a terraform destroy, resources are deleted in parallel, so the LBU on this Net
 		// can be in any transient state (reloading, reconfiguring, deleting, etc.).
 		// Checking only for specific states would miss cases like a concurrent
 		// backend vms unlink putting the LBU in "reloading" state (like in TF-2 integration test)
-		_, err := oapihelpers.RetryOnCodes(ctx, []string{"1005"}, func() (resp any, err error) {
+		//
+		// We also retry on the 1018 error, which is returned when NAT services are still dependent on the Internet Service net.
+		// Checking the linked NATs state is not sufficient, as it may still be in the process of being deleted.
+		// Order of deletion is not deterministic, and the Internet Service Link net may be deleted before the NAT service.
+		_, err := oapihelpers.RetryOnCodes(ctx, []string{"1005", "1018"}, func() (resp any, err error) {
 			return r.Client.UnlinkInternetService(ctx, unlinkReq, options.WithRetryTimeout(timeout))
 		}, timeout)
 		if err != nil {

--- a/tests/data/oapi/nets/TF-109_nic_datasource_attributes_ok/step1.nic_datasource_attributes_ok.ref
+++ b/tests/data/oapi/nets/TF-109_nic_datasource_attributes_ok/step1.nic_datasource_attributes_ok.ref
@@ -774,7 +774,7 @@
                     "attributes": {
                         "actions_on_next_boot": [
                             {
-                                "secure_boot": ""
+                                "secure_boot": "none"
                             }
                         ],
                         "admin_password": "",
@@ -794,7 +794,7 @@
                                 "device_name": "/dev/sda1"
                             }
                         ],
-                        "boot_mode": "legacy",
+                        "boot_mode": "uefi",
                         "bsu_optimized": false,
                         "client_token": "",
                         "creation_date": "########",

--- a/tests/data/oapi/nets/TF-111_nic_link_resource_attributes_ok/step1.nic_link_resource_attributes_ok.ref
+++ b/tests/data/oapi/nets/TF-111_nic_link_resource_attributes_ok/step1.nic_link_resource_attributes_ok.ref
@@ -229,7 +229,7 @@
                     "attributes": {
                         "actions_on_next_boot": [
                             {
-                                "secure_boot": ""
+                                "secure_boot": "none"
                             }
                         ],
                         "admin_password": "",
@@ -249,7 +249,7 @@
                                 "device_name": "/dev/sda1"
                             }
                         ],
-                        "boot_mode": "legacy",
+                        "boot_mode": "uefi",
                         "bsu_optimized": false,
                         "client_token": "",
                         "creation_date": "########",

--- a/tests/data/oapi/nets/TF-113_nics_datasource_attributes_ok/step1.nics_datasource_attributes_ok.ref
+++ b/tests/data/oapi/nets/TF-113_nics_datasource_attributes_ok/step1.nics_datasource_attributes_ok.ref
@@ -152,11 +152,49 @@
                                 "account_id": "##id-1##",
                                 "description": "",
                                 "is_source_dest_checked": true,
+                                "link_nic": [],
+                                "link_public_ip": [],
+                                "mac_address": "########",
+                                "net_id": "##id-4##",
+                                "nic_id": "##id-12##",
+                                "private_dns_name": "########",
+                                "private_ips": [
+                                    {
+                                        "is_primary": true,
+                                        "link_public_ip": [],
+                                        "private_dns_name": "########",
+                                        "private_ip": "########"
+                                    }
+                                ],
+                                "security_groups": [
+                                    {
+                                        "security_group_id": "##id-6##",
+                                        "security_group_name": "########"
+                                    }
+                                ],
+                                "state": "available",
+                                "subnet_id": "##id-13##",
+                                "subregion_name": "us-east-2b",
+                                "tags": [
+                                    {
+                                        "key": "Key:",
+                                        "value": ":value-tags"
+                                    },
+                                    {
+                                        "key": "Key-2",
+                                        "value": "value-tags-2"
+                                    }
+                                ]
+                            },
+                            {
+                                "account_id": "##id-1##",
+                                "description": "",
+                                "is_source_dest_checked": true,
                                 "link_nic": [
                                     {
                                         "delete_on_vm_deletion": false,
                                         "device_number": 2,
-                                        "link_nic_id": "##id-12##",
+                                        "link_nic_id": "##id-14##",
                                         "state": "attached",
                                         "vm_account_id": "##id-1##",
                                         "vm_id": "##id-3##"
@@ -165,7 +203,7 @@
                                 "link_public_ip": [],
                                 "mac_address": "########",
                                 "net_id": "##id-4##",
-                                "nic_id": "##id-13##",
+                                "nic_id": "##id-15##",
                                 "private_dns_name": "########",
                                 "private_ips": [
                                     {
@@ -194,44 +232,6 @@
                                     {
                                         "key": "Name",
                                         "value": "Nic-2"
-                                    }
-                                ]
-                            },
-                            {
-                                "account_id": "##id-1##",
-                                "description": "",
-                                "is_source_dest_checked": true,
-                                "link_nic": [],
-                                "link_public_ip": [],
-                                "mac_address": "########",
-                                "net_id": "##id-4##",
-                                "nic_id": "##id-14##",
-                                "private_dns_name": "########",
-                                "private_ips": [
-                                    {
-                                        "is_primary": true,
-                                        "link_public_ip": [],
-                                        "private_dns_name": "########",
-                                        "private_ip": "########"
-                                    }
-                                ],
-                                "security_groups": [
-                                    {
-                                        "security_group_id": "##id-6##",
-                                        "security_group_name": "########"
-                                    }
-                                ],
-                                "state": "available",
-                                "subnet_id": "##id-15##",
-                                "subregion_name": "us-east-2b",
-                                "tags": [
-                                    {
-                                        "key": "Key:",
-                                        "value": ":value-tags"
-                                    },
-                                    {
-                                        "key": "Key-2",
-                                        "value": "value-tags-2"
                                     }
                                 ]
                             }
@@ -257,22 +257,13 @@
                         "nics": [
                             {
                                 "account_id": "##id-1##",
-                                "description": "Primary network interface",
+                                "description": "",
                                 "is_source_dest_checked": true,
-                                "link_nic": [
-                                    {
-                                        "delete_on_vm_deletion": true,
-                                        "device_number": 0,
-                                        "link_nic_id": "##id-9##",
-                                        "state": "attached",
-                                        "vm_account_id": "##id-1##",
-                                        "vm_id": "##id-3##"
-                                    }
-                                ],
+                                "link_nic": [],
                                 "link_public_ip": [],
                                 "mac_address": "########",
                                 "net_id": "##id-4##",
-                                "nic_id": "##id-10##",
+                                "nic_id": "##id-12##",
                                 "private_dns_name": "########",
                                 "private_ips": [
                                     {
@@ -288,10 +279,19 @@
                                         "security_group_name": "########"
                                     }
                                 ],
-                                "state": "in-use",
-                                "subnet_id": "##id-7##",
-                                "subregion_name": "us-east-2a",
-                                "tags": []
+                                "state": "available",
+                                "subnet_id": "##id-13##",
+                                "subregion_name": "us-east-2b",
+                                "tags": [
+                                    {
+                                        "key": "Key:",
+                                        "value": ":value-tags"
+                                    },
+                                    {
+                                        "key": "Key-2",
+                                        "value": "value-tags-2"
+                                    }
+                                ]
                             },
                             {
                                 "account_id": "##id-1##",
@@ -348,13 +348,13 @@
                             },
                             {
                                 "account_id": "##id-1##",
-                                "description": "",
+                                "description": "Primary network interface",
                                 "is_source_dest_checked": true,
                                 "link_nic": [
                                     {
-                                        "delete_on_vm_deletion": false,
-                                        "device_number": 2,
-                                        "link_nic_id": "##id-12##",
+                                        "delete_on_vm_deletion": true,
+                                        "device_number": 0,
+                                        "link_nic_id": "##id-9##",
                                         "state": "attached",
                                         "vm_account_id": "##id-1##",
                                         "vm_id": "##id-3##"
@@ -363,7 +363,45 @@
                                 "link_public_ip": [],
                                 "mac_address": "########",
                                 "net_id": "##id-4##",
-                                "nic_id": "##id-13##",
+                                "nic_id": "##id-10##",
+                                "private_dns_name": "########",
+                                "private_ips": [
+                                    {
+                                        "is_primary": true,
+                                        "link_public_ip": [],
+                                        "private_dns_name": "########",
+                                        "private_ip": "########"
+                                    }
+                                ],
+                                "security_groups": [
+                                    {
+                                        "security_group_id": "##id-6##",
+                                        "security_group_name": "########"
+                                    }
+                                ],
+                                "state": "in-use",
+                                "subnet_id": "##id-7##",
+                                "subregion_name": "us-east-2a",
+                                "tags": []
+                            },
+                            {
+                                "account_id": "##id-1##",
+                                "description": "",
+                                "is_source_dest_checked": true,
+                                "link_nic": [
+                                    {
+                                        "delete_on_vm_deletion": false,
+                                        "device_number": 2,
+                                        "link_nic_id": "##id-14##",
+                                        "state": "attached",
+                                        "vm_account_id": "##id-1##",
+                                        "vm_id": "##id-3##"
+                                    }
+                                ],
+                                "link_public_ip": [],
+                                "mac_address": "########",
+                                "net_id": "##id-4##",
+                                "nic_id": "##id-15##",
                                 "private_dns_name": "########",
                                 "private_ips": [
                                     {
@@ -392,44 +430,6 @@
                                     {
                                         "key": "Name",
                                         "value": "Nic-2"
-                                    }
-                                ]
-                            },
-                            {
-                                "account_id": "##id-1##",
-                                "description": "",
-                                "is_source_dest_checked": true,
-                                "link_nic": [],
-                                "link_public_ip": [],
-                                "mac_address": "########",
-                                "net_id": "##id-4##",
-                                "nic_id": "##id-14##",
-                                "private_dns_name": "########",
-                                "private_ips": [
-                                    {
-                                        "is_primary": true,
-                                        "link_public_ip": [],
-                                        "private_dns_name": "########",
-                                        "private_ip": "########"
-                                    }
-                                ],
-                                "security_groups": [
-                                    {
-                                        "security_group_id": "##id-6##",
-                                        "security_group_name": "########"
-                                    }
-                                ],
-                                "state": "available",
-                                "subnet_id": "##id-15##",
-                                "subregion_name": "us-east-2b",
-                                "tags": [
-                                    {
-                                        "key": "Key:",
-                                        "value": ":value-tags"
-                                    },
-                                    {
-                                        "key": "Key-2",
-                                        "value": "value-tags-2"
                                     }
                                 ]
                             }
@@ -455,22 +455,13 @@
                         "nics": [
                             {
                                 "account_id": "##id-1##",
-                                "description": "Primary network interface",
+                                "description": "",
                                 "is_source_dest_checked": true,
-                                "link_nic": [
-                                    {
-                                        "delete_on_vm_deletion": true,
-                                        "device_number": 0,
-                                        "link_nic_id": "##id-9##",
-                                        "state": "attached",
-                                        "vm_account_id": "##id-1##",
-                                        "vm_id": "##id-3##"
-                                    }
-                                ],
+                                "link_nic": [],
                                 "link_public_ip": [],
                                 "mac_address": "########",
                                 "net_id": "##id-4##",
-                                "nic_id": "##id-10##",
+                                "nic_id": "##id-12##",
                                 "private_dns_name": "########",
                                 "private_ips": [
                                     {
@@ -486,10 +477,19 @@
                                         "security_group_name": "########"
                                     }
                                 ],
-                                "state": "in-use",
-                                "subnet_id": "##id-7##",
-                                "subregion_name": "us-east-2a",
-                                "tags": []
+                                "state": "available",
+                                "subnet_id": "##id-13##",
+                                "subregion_name": "us-east-2b",
+                                "tags": [
+                                    {
+                                        "key": "Key:",
+                                        "value": ":value-tags"
+                                    },
+                                    {
+                                        "key": "Key-2",
+                                        "value": "value-tags-2"
+                                    }
+                                ]
                             },
                             {
                                 "account_id": "##id-1##",
@@ -546,13 +546,13 @@
                             },
                             {
                                 "account_id": "##id-1##",
-                                "description": "",
+                                "description": "Primary network interface",
                                 "is_source_dest_checked": true,
                                 "link_nic": [
                                     {
-                                        "delete_on_vm_deletion": false,
-                                        "device_number": 2,
-                                        "link_nic_id": "##id-12##",
+                                        "delete_on_vm_deletion": true,
+                                        "device_number": 0,
+                                        "link_nic_id": "##id-9##",
                                         "state": "attached",
                                         "vm_account_id": "##id-1##",
                                         "vm_id": "##id-3##"
@@ -561,7 +561,45 @@
                                 "link_public_ip": [],
                                 "mac_address": "########",
                                 "net_id": "##id-4##",
-                                "nic_id": "##id-13##",
+                                "nic_id": "##id-10##",
+                                "private_dns_name": "########",
+                                "private_ips": [
+                                    {
+                                        "is_primary": true,
+                                        "link_public_ip": [],
+                                        "private_dns_name": "########",
+                                        "private_ip": "########"
+                                    }
+                                ],
+                                "security_groups": [
+                                    {
+                                        "security_group_id": "##id-6##",
+                                        "security_group_name": "########"
+                                    }
+                                ],
+                                "state": "in-use",
+                                "subnet_id": "##id-7##",
+                                "subregion_name": "us-east-2a",
+                                "tags": []
+                            },
+                            {
+                                "account_id": "##id-1##",
+                                "description": "",
+                                "is_source_dest_checked": true,
+                                "link_nic": [
+                                    {
+                                        "delete_on_vm_deletion": false,
+                                        "device_number": 2,
+                                        "link_nic_id": "##id-14##",
+                                        "state": "attached",
+                                        "vm_account_id": "##id-1##",
+                                        "vm_id": "##id-3##"
+                                    }
+                                ],
+                                "link_public_ip": [],
+                                "mac_address": "########",
+                                "net_id": "##id-4##",
+                                "nic_id": "##id-15##",
                                 "private_dns_name": "########",
                                 "private_ips": [
                                     {
@@ -590,44 +628,6 @@
                                     {
                                         "key": "Name",
                                         "value": "Nic-2"
-                                    }
-                                ]
-                            },
-                            {
-                                "account_id": "##id-1##",
-                                "description": "",
-                                "is_source_dest_checked": true,
-                                "link_nic": [],
-                                "link_public_ip": [],
-                                "mac_address": "########",
-                                "net_id": "##id-4##",
-                                "nic_id": "##id-14##",
-                                "private_dns_name": "########",
-                                "private_ips": [
-                                    {
-                                        "is_primary": true,
-                                        "link_public_ip": [],
-                                        "private_dns_name": "########",
-                                        "private_ip": "########"
-                                    }
-                                ],
-                                "security_groups": [
-                                    {
-                                        "security_group_id": "##id-6##",
-                                        "security_group_name": "########"
-                                    }
-                                ],
-                                "state": "available",
-                                "subnet_id": "##id-15##",
-                                "subregion_name": "us-east-2b",
-                                "tags": [
-                                    {
-                                        "key": "Key:",
-                                        "value": ":value-tags"
-                                    },
-                                    {
-                                        "key": "Key-2",
-                                        "value": "value-tags-2"
                                     }
                                 ]
                             }
@@ -659,7 +659,7 @@
                                 "link_public_ip": [],
                                 "mac_address": "########",
                                 "net_id": "##id-4##",
-                                "nic_id": "##id-14##",
+                                "nic_id": "##id-12##",
                                 "private_dns_name": "########",
                                 "private_ips": [
                                     {
@@ -676,7 +676,7 @@
                                     }
                                 ],
                                 "state": "available",
-                                "subnet_id": "##id-15##",
+                                "subnet_id": "##id-13##",
                                 "subregion_name": "us-east-2b",
                                 "tags": [
                                     {
@@ -804,13 +804,13 @@
                     "attributes": {
                         "account_id": "##id-1##",
                         "description": "",
-                        "id": "##id-13##",
+                        "id": "##id-15##",
                         "is_source_dest_checked": true,
                         "link_nic": [],
                         "link_public_ip": [],
                         "mac_address": "########",
                         "net_id": "##id-4##",
-                        "nic_id": "##id-13##",
+                        "nic_id": "##id-15##",
                         "private_dns_name": "########",
                         "private_ip": "########",
                         "private_ips": [
@@ -872,13 +872,13 @@
                     "attributes": {
                         "account_id": "##id-1##",
                         "description": "",
-                        "id": "##id-14##",
+                        "id": "##id-12##",
                         "is_source_dest_checked": true,
                         "link_nic": [],
                         "link_public_ip": [],
                         "mac_address": "########",
                         "net_id": "##id-4##",
-                        "nic_id": "##id-14##",
+                        "nic_id": "##id-12##",
                         "private_dns_name": "########",
                         "private_ip": "########",
                         "private_ips": [
@@ -901,7 +901,7 @@
                             }
                         ],
                         "state": "available",
-                        "subnet_id": "##id-15##",
+                        "subnet_id": "##id-13##",
                         "subregion_name": "us-east-2b",
                         "tags": [
                             {
@@ -972,9 +972,9 @@
                     "attributes": {
                         "delete_on_vm_deletion": false,
                         "device_number": 2,
-                        "id": "##id-12##",
-                        "link_nic_id": "##id-12##",
-                        "nic_id": "##id-13##",
+                        "id": "##id-14##",
+                        "link_nic_id": "##id-14##",
+                        "nic_id": "##id-15##",
                         "request_id": "########",
                         "state": null,
                         "timeouts": null,
@@ -1074,13 +1074,13 @@
                     "schema_version": 0,
                     "attributes": {
                         "available_ips_count": "########",
-                        "id": "##id-15##",
+                        "id": "##id-13##",
                         "ip_range": "10.5.2.0/24",
                         "map_public_ip_on_launch": false,
                         "net_id": "##id-4##",
                         "request_id": "########",
                         "state": "available",
-                        "subnet_id": "##id-15##",
+                        "subnet_id": "##id-13##",
                         "subregion_name": "us-east-2b",
                         "tags": [],
                         "timeouts": null
@@ -1104,7 +1104,7 @@
                     "attributes": {
                         "actions_on_next_boot": [
                             {
-                                "secure_boot": ""
+                                "secure_boot": "none"
                             }
                         ],
                         "admin_password": "",
@@ -1124,7 +1124,7 @@
                                 "device_name": "/dev/sda1"
                             }
                         ],
-                        "boot_mode": "legacy",
+                        "boot_mode": "uefi",
                         "bsu_optimized": false,
                         "client_token": "",
                         "creation_date": "########",

--- a/tests/data/oapi/nets/TF-144_vm_resource_centos_attributes_ok/step1.vm_resource_centos_ok.ref
+++ b/tests/data/oapi/nets/TF-144_vm_resource_centos_attributes_ok/step1.vm_resource_centos_ok.ref
@@ -425,7 +425,7 @@
                     "attributes": {
                         "actions_on_next_boot": [
                             {
-                                "secure_boot": ""
+                                "secure_boot": "none"
                             }
                         ],
                         "admin_password": "",
@@ -445,7 +445,7 @@
                                 "device_name": "/dev/sda1"
                             }
                         ],
-                        "boot_mode": "legacy",
+                        "boot_mode": "uefi",
                         "bsu_optimized": false,
                         "client_token": "",
                         "creation_date": "########",
@@ -527,7 +527,7 @@
                     "attributes": {
                         "actions_on_next_boot": [
                             {
-                                "secure_boot": ""
+                                "secure_boot": "none"
                             }
                         ],
                         "admin_password": "",
@@ -547,7 +547,7 @@
                                 "device_name": "/dev/sda1"
                             }
                         ],
-                        "boot_mode": "legacy",
+                        "boot_mode": "uefi",
                         "bsu_optimized": false,
                         "client_token": "",
                         "creation_date": "########",
@@ -629,7 +629,7 @@
                     "attributes": {
                         "actions_on_next_boot": [
                             {
-                                "secure_boot": ""
+                                "secure_boot": "none"
                             }
                         ],
                         "admin_password": "",
@@ -649,7 +649,7 @@
                                 "device_name": "/dev/sda1"
                             }
                         ],
-                        "boot_mode": "legacy",
+                        "boot_mode": "uefi",
                         "bsu_optimized": false,
                         "client_token": "",
                         "creation_date": "########",

--- a/tests/data/oapi/nets/TF-145_vm_resource_private_with_multiple_NICs_attributes_ok/step1.vm_resource_private_with_multiple_NICs_ok.ref
+++ b/tests/data/oapi/nets/TF-145_vm_resource_private_with_multiple_NICs_attributes_ok/step1.vm_resource_private_with_multiple_NICs_ok.ref
@@ -232,7 +232,7 @@
                     "attributes": {
                         "actions_on_next_boot": [
                             {
-                                "secure_boot": ""
+                                "secure_boot": "none"
                             }
                         ],
                         "admin_password": "",
@@ -252,7 +252,7 @@
                                 "device_name": "/dev/sda1"
                             }
                         ],
-                        "boot_mode": "legacy",
+                        "boot_mode": "uefi",
                         "bsu_optimized": false,
                         "client_token": "",
                         "creation_date": "########",

--- a/tests/data/oapi/nets/TF-2_internet_facing_lbu_update_backend_vms_ok/step1.private_internet_facing_load_balancer_add_backend_vm_attributes_ok.ref
+++ b/tests/data/oapi/nets/TF-2_internet_facing_lbu_update_backend_vms_ok/step1.private_internet_facing_load_balancer_add_backend_vm_attributes_ok.ref
@@ -572,7 +572,7 @@
                     "attributes": {
                         "actions_on_next_boot": [
                             {
-                                "secure_boot": ""
+                                "secure_boot": "none"
                             }
                         ],
                         "admin_password": "",
@@ -592,7 +592,7 @@
                                 "device_name": "/dev/sda1"
                             }
                         ],
-                        "boot_mode": "legacy",
+                        "boot_mode": "uefi",
                         "bsu_optimized": false,
                         "client_token": "",
                         "creation_date": "########",

--- a/tests/data/oapi/nets/TF-65_Check_IGW_Destroy/step1.test_destroy_igw.ref
+++ b/tests/data/oapi/nets/TF-65_Check_IGW_Destroy/step1.test_destroy_igw.ref
@@ -879,7 +879,7 @@
                     "attributes": {
                         "actions_on_next_boot": [
                             {
-                                "secure_boot": ""
+                                "secure_boot": "none"
                             }
                         ],
                         "admin_password": "",
@@ -899,7 +899,7 @@
                                 "device_name": "/dev/sda1"
                             }
                         ],
-                        "boot_mode": "legacy",
+                        "boot_mode": "uefi",
                         "bsu_optimized": false,
                         "client_token": "",
                         "creation_date": "########",
@@ -1057,7 +1057,7 @@
                     "attributes": {
                         "actions_on_next_boot": [
                             {
-                                "secure_boot": ""
+                                "secure_boot": "none"
                             }
                         ],
                         "admin_password": "",
@@ -1077,7 +1077,7 @@
                                 "device_name": "/dev/sda1"
                             }
                         ],
-                        "boot_mode": "legacy",
+                        "boot_mode": "uefi",
                         "bsu_optimized": false,
                         "client_token": "",
                         "creation_date": "########",
@@ -1235,7 +1235,7 @@
                     "attributes": {
                         "actions_on_next_boot": [
                             {
-                                "secure_boot": ""
+                                "secure_boot": "none"
                             }
                         ],
                         "admin_password": "",
@@ -1255,7 +1255,7 @@
                                 "device_name": "/dev/sda1"
                             }
                         ],
-                        "boot_mode": "legacy",
+                        "boot_mode": "uefi",
                         "bsu_optimized": false,
                         "client_token": "",
                         "creation_date": "########",
@@ -1421,7 +1421,7 @@
                     "attributes": {
                         "actions_on_next_boot": [
                             {
-                                "secure_boot": ""
+                                "secure_boot": "none"
                             }
                         ],
                         "admin_password": "",
@@ -1441,7 +1441,7 @@
                                 "device_name": "/dev/sda1"
                             }
                         ],
-                        "boot_mode": "legacy",
+                        "boot_mode": "uefi",
                         "bsu_optimized": false,
                         "client_token": "",
                         "creation_date": "########",
@@ -1599,7 +1599,7 @@
                     "attributes": {
                         "actions_on_next_boot": [
                             {
-                                "secure_boot": ""
+                                "secure_boot": "none"
                             }
                         ],
                         "admin_password": "",
@@ -1619,7 +1619,7 @@
                                 "device_name": "/dev/sda1"
                             }
                         ],
-                        "boot_mode": "legacy",
+                        "boot_mode": "uefi",
                         "bsu_optimized": false,
                         "client_token": "",
                         "creation_date": "########",
@@ -1777,7 +1777,7 @@
                     "attributes": {
                         "actions_on_next_boot": [
                             {
-                                "secure_boot": ""
+                                "secure_boot": "none"
                             }
                         ],
                         "admin_password": "",
@@ -1797,7 +1797,7 @@
                                 "device_name": "/dev/sda1"
                             }
                         ],
-                        "boot_mode": "legacy",
+                        "boot_mode": "uefi",
                         "bsu_optimized": false,
                         "client_token": "",
                         "creation_date": "########",

--- a/tests/data/oapi/vm/TF-212_vm_primary_nic_ok/step1.vm_primary_nic_ok.ref
+++ b/tests/data/oapi/vm/TF-212_vm_primary_nic_ok/step1.vm_primary_nic_ok.ref
@@ -26,7 +26,10 @@
                         "timeouts": null
                     },
                     "sensitive_attributes": [],
-                    "identity_schema_version": 0
+                    "identity_schema_version": 0,
+                    "dependencies": [
+                        "random_string.suffix"
+                    ]
                 }
             ]
         },
@@ -249,7 +252,8 @@
                         "outscale_nic.nic02",
                         "outscale_subnet.subnet01",
                         "outscale_subnet.subnet02",
-                        "outscale_vm.vm01"
+                        "outscale_vm.vm01",
+                        "random_string.suffix"
                     ]
                 }
             ]
@@ -485,7 +489,8 @@
                         "outscale_keypair.keypair01",
                         "outscale_net.net01",
                         "outscale_nic.nic01",
-                        "outscale_subnet.subnet01"
+                        "outscale_subnet.subnet01",
+                        "random_string.suffix"
                     ]
                 }
             ]

--- a/tests/data/oapi/vm/TF-212_vm_primary_nic_ok/step1.vm_primary_nic_ok.tf
+++ b/tests/data/oapi/vm/TF-212_vm_primary_nic_ok/step1.vm_primary_nic_ok.tf
@@ -27,7 +27,7 @@ resource "outscale_nic" "nic03" {
 }
 
 resource "outscale_keypair" "keypair01" {
-  keypair_name = "terraform-keypair-for-vm"
+  keypair_name = "test-keypair-${random_string.suffix[0].result}"
 }
 
 resource "outscale_vm" "vm01" {

--- a/tests/data/oapi/vm/TF-212_vm_primary_nic_ok/step2.vm_primary_nic_with_nic_link_ok.ref
+++ b/tests/data/oapi/vm/TF-212_vm_primary_nic_ok/step2.vm_primary_nic_with_nic_link_ok.ref
@@ -26,7 +26,10 @@
                         "timeouts": null
                     },
                     "sensitive_attributes": [],
-                    "identity_schema_version": 0
+                    "identity_schema_version": 0,
+                    "dependencies": [
+                        "random_string.suffix"
+                    ]
                 }
             ]
         },
@@ -267,7 +270,8 @@
                         "outscale_nic.nic03",
                         "outscale_subnet.subnet01",
                         "outscale_subnet.subnet02",
-                        "outscale_vm.vm01"
+                        "outscale_vm.vm01",
+                        "random_string.suffix"
                     ]
                 }
             ]
@@ -543,7 +547,8 @@
                         "outscale_keypair.keypair01",
                         "outscale_net.net01",
                         "outscale_nic.nic01",
-                        "outscale_subnet.subnet01"
+                        "outscale_subnet.subnet01",
+                        "random_string.suffix"
                     ]
                 }
             ]

--- a/tests/data/oapi/vm/TF-212_vm_primary_nic_ok/step2.vm_primary_nic_with_nic_link_ok.tf
+++ b/tests/data/oapi/vm/TF-212_vm_primary_nic_ok/step2.vm_primary_nic_with_nic_link_ok.tf
@@ -27,7 +27,7 @@ resource "outscale_nic" "nic03" {
 }
 
 resource "outscale_keypair" "keypair01" {
-  keypair_name = "terraform-keypair-for-vm"
+  keypair_name = "test-keypair-${random_string.suffix[0].result}"
 }
 
 resource "outscale_vm" "vm01" {


### PR DESCRIPTION
## Description

When calling `terraform destroy` with an Internet Service resource where the common Net had a linked NAT, destruction failed. The `destroy` command is called in parallel on all resources, and the Internet Service Link can be destroyed before the NAT would.
Retrying the deletion on the conflict code is the only solution we have for now.

- **🐛 fix(internet_service_link): retry on conflict when resources are being deleted**
- **:alien: chore(test): update ref files**

## Type of Change

Please check the relevant option(s):

- [X] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [X] Manual testing
- [ ] Unit tests
- [ ] Acceptance tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [X] I have followed the [Contributing Guidelines](CONTRIBUTING.md)
* [X] I have added tests or explained why they are not needed
* [X] I have updated relevant documentation (README, examples, etc.)
* [X] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [X] My commits include appropriate [Gitmoji](https://gitmoji.dev/)
