### PR TITLE
✨ feat(flexible_gpu): find first available AZ at creation

### DIFF
--- a/internal/services/oapi/resource_flexible_gpu.go
+++ b/internal/services/oapi/resource_flexible_gpu.go
@@ -108,9 +108,11 @@ func (r *fgpuResource) Schema(ctx context.Context, _ resource.SchemaRequest, res
 		},
 		Attributes: map[string]schema.Attribute{
 			"subregion_name": schema.StringAttribute{
-				Required: true,
+				Computed: true,
+				Optional: true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
+					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"model_name": schema.StringAttribute{
@@ -161,8 +163,7 @@ func (r *fgpuResource) Create(ctx context.Context, req resource.CreateRequest, r
 	}
 
 	createReq := osc.CreateFlexibleGpuRequest{
-		ModelName:     data.ModelName.ValueString(),
-		SubregionName: data.SubregionName.ValueString(),
+		ModelName: data.ModelName.ValueString(),
 	}
 	if !data.DeleteOnVmDeletion.IsNull() {
 		createReq.DeleteOnVmDeletion = data.DeleteOnVmDeletion.ValueBoolPointer()
@@ -176,11 +177,49 @@ func (r *fgpuResource) Create(ctx context.Context, req resource.CreateRequest, r
 		return
 	}
 
-	createResp, err := r.Client.CreateFlexibleGpu(ctx, createReq, options.WithRetryTimeout(timeout))
-	if err != nil {
-		resp.Diagnostics.AddError(flexibleGpuErrCreate, err.Error())
-		return
+	var createResp *osc.CreateFlexibleGpuResponse
+	var err error
+	switch {
+	case fwhelpers.IsSet(data.SubregionName):
+		createReq.SubregionName = data.SubregionName.ValueString()
+		createResp, err = r.Client.CreateFlexibleGpu(ctx, createReq, options.WithRetryTimeout(timeout))
+		if err != nil {
+			resp.Diagnostics.AddError(flexibleGpuErrCreate, err.Error())
+			return
+		}
+	default:
+		subregionResp, err := r.Client.ReadSubregions(ctx, osc.ReadSubregionsRequest{})
+		if err != nil {
+			resp.Diagnostics.AddError(flexibleGpuErrCreate, err.Error())
+			return
+		}
+		azs := ptr.From(subregionResp.Subregions)
+
+		azsNames := make([]string, 0, len(azs))
+		var fgpuErr error
+		for _, az := range azs {
+			name := ptr.From(az.SubregionName)
+			azsNames = append(azsNames, name)
+			createReq.SubregionName = name
+
+			createResp, fgpuErr = r.Client.CreateFlexibleGpu(ctx, createReq, options.WithRetryTimeout(timeout))
+			// 409 with code '10001' means there's no capacity for the requested model in the AZ
+			// We return an error only if the error is not a capacity error
+			if fgpuErr != nil && !osc.HasErrorCode(fgpuErr, []string{"10001"}) {
+				resp.Diagnostics.AddError(flexibleGpuErrCreate, fgpuErr.Error())
+				return
+			}
+			// If no error, the GPU was successfully created
+			if fgpuErr == nil {
+				break
+			}
+		}
+		if fgpuErr != nil {
+			resp.Diagnostics.AddError(flexibleGpuErrCreate, fmt.Sprintf("The requested Flexible GPU model is not available in any of the following subregions: %v. API Error: %v", azsNames, fgpuErr))
+			return
+		}
 	}
+
 	fGpu := ptr.From(createResp.FlexibleGpu)
 
 	data.FlexibleGpuId = to.String(fGpu.FlexibleGpuId)

--- a/internal/services/oapi/resource_flexible_gpu_test.go
+++ b/internal/services/oapi/resource_flexible_gpu_test.go
@@ -11,8 +11,7 @@ import (
 
 func TestAccOthers_FlexibleGpu_Basic(t *testing.T) {
 	resourceName := "outscale_flexible_gpu.fGPU-1"
-	resource.ParallelTest(t, resource.TestCase{
-		ProtoV6ProviderFactories: testacc.ProtoV6ProviderFactories(),
+	testacc.ParallelTest(t, resource.TestCase{
 		Steps: []resource.TestStep{
 			{
 				Config: testAccFlexibleGpuConfig(utils.GetRegion(), false),
@@ -29,6 +28,23 @@ func TestAccOthers_FlexibleGpu_Basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "model_name"),
 					resource.TestCheckResourceAttrSet(resourceName, "generation"),
 					resource.TestCheckResourceAttrSet(resourceName, "subregion_name"),
+					resource.TestCheckResourceAttr(resourceName, "delete_on_vm_deletion", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccOthers_FlexibleGpu_AnyAZ(t *testing.T) {
+	resourceName := "outscale_flexible_gpu.fGPU-1"
+
+	testacc.ParallelTest(t, resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFlexibleGpuConfigAnyAZ,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "model_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "generation"),
 					resource.TestCheckResourceAttr(resourceName, "delete_on_vm_deletion", "true"),
 				),
 			},
@@ -59,3 +75,18 @@ func testAccFlexibleGpuConfig(region string, deletion bool) string {
 		}
 	`, region, deletion)
 }
+
+var testAccFlexibleGpuConfigAnyAZ = `
+resource "outscale_flexible_gpu" "fGPU-1" {
+    model_name             =  "nvidia-p6"
+    generation             =  "v5"
+    delete_on_vm_deletion  =  true
+}
+
+data "outscale_flexible_gpu" "data_fGPU-1" {
+	filter {
+		name = "flexible_gpu_ids"
+		values = [outscale_flexible_gpu.fGPU-1.flexible_gpu_id]
+	}
+}
+`

--- a/tests/data/oapi/flexible_gpu/TF-172_flexible_gpu_resource_attributes_ok_mandatory_param_only/step1.flexible_gpu_resource_attributes_ok_mandatory_param_only.ref
+++ b/tests/data/oapi/flexible_gpu/TF-172_flexible_gpu_resource_attributes_ok_mandatory_param_only/step1.flexible_gpu_resource_attributes_ok_mandatory_param_only.ref
@@ -20,7 +20,7 @@
                         "id": "##id-0##",
                         "model_name": "nvidia-p6",
                         "state": "allocated",
-                        "subregion_name": "eu-west-2a",
+                        "subregion_name": "########",
                         "timeouts": null,
                         "vm_id": ""
                     },

--- a/tests/data/oapi/flexible_gpu/TF-172_flexible_gpu_resource_attributes_ok_mandatory_param_only/step1.flexible_gpu_resource_attributes_ok_mandatory_param_only.tf
+++ b/tests/data/oapi/flexible_gpu/TF-172_flexible_gpu_resource_attributes_ok_mandatory_param_only/step1.flexible_gpu_resource_attributes_ok_mandatory_param_only.tf
@@ -2,4 +2,3 @@ resource "outscale_flexible_gpu" "fGPU-2" {
   model_name     = "nvidia-p6"
   subregion_name = "${var.region}a"
 }
-

--- a/tests/data/oapi/flexible_gpu/TF-172_flexible_gpu_resource_attributes_ok_mandatory_param_only/step2.flexible_gpu_resource_attributes_ok_update_delete_on_vm_deletion.ref
+++ b/tests/data/oapi/flexible_gpu/TF-172_flexible_gpu_resource_attributes_ok_mandatory_param_only/step2.flexible_gpu_resource_attributes_ok_update_delete_on_vm_deletion.ref
@@ -20,7 +20,7 @@
                         "id": "##id-0##",
                         "model_name": "nvidia-p6",
                         "state": "allocated",
-                        "subregion_name": "eu-west-2a",
+                        "subregion_name": "########",
                         "timeouts": null,
                         "vm_id": ""
                     },

--- a/tests/data/oapi/flexible_gpu/TF-172_flexible_gpu_resource_attributes_ok_mandatory_param_only/step2.flexible_gpu_resource_attributes_ok_update_delete_on_vm_deletion.tf
+++ b/tests/data/oapi/flexible_gpu/TF-172_flexible_gpu_resource_attributes_ok_mandatory_param_only/step2.flexible_gpu_resource_attributes_ok_update_delete_on_vm_deletion.tf
@@ -3,4 +3,3 @@ resource "outscale_flexible_gpu" "fGPU-2" {
   subregion_name        = "${var.region}a"
   delete_on_vm_deletion = true
 }
-

--- a/tests/data/oapi/flexible_gpu/TF-173_flexible_gpu_resource_attributes_ok_all_params/step1.flexible_gpu_resource_attributes_ok_all_params.ref
+++ b/tests/data/oapi/flexible_gpu/TF-173_flexible_gpu_resource_attributes_ok_all_params/step1.flexible_gpu_resource_attributes_ok_all_params.ref
@@ -20,7 +20,7 @@
                         "id": "##id-0##",
                         "model_name": "nvidia-p6",
                         "state": "allocated",
-                        "subregion_name": "eu-west-2a",
+                        "subregion_name": "########",
                         "timeouts": null,
                         "vm_id": ""
                     },

--- a/tests/data/oapi/flexible_gpu/TF-173_flexible_gpu_resource_attributes_ok_all_params/step1.flexible_gpu_resource_attributes_ok_all_params.tf
+++ b/tests/data/oapi/flexible_gpu/TF-173_flexible_gpu_resource_attributes_ok_all_params/step1.flexible_gpu_resource_attributes_ok_all_params.tf
@@ -1,6 +1,5 @@
 resource "outscale_flexible_gpu" "fGPU-1" {
   model_name            = "nvidia-p6"
   generation            = var.fgpu_gen
-  subregion_name        = "${var.region}a"
   delete_on_vm_deletion = true
 }

--- a/tests/data/oapi/flexible_gpu/TF-173_flexible_gpu_resource_attributes_ok_all_params/step2.flexible_gpu_resource_attributes_ok_all_params_update_delete_on_vm_deletion.ref
+++ b/tests/data/oapi/flexible_gpu/TF-173_flexible_gpu_resource_attributes_ok_all_params/step2.flexible_gpu_resource_attributes_ok_all_params_update_delete_on_vm_deletion.ref
@@ -20,7 +20,7 @@
                         "id": "##id-0##",
                         "model_name": "nvidia-p6",
                         "state": "allocated",
-                        "subregion_name": "eu-west-2a",
+                        "subregion_name": "########",
                         "timeouts": null,
                         "vm_id": ""
                     },

--- a/tests/data/oapi/flexible_gpu/TF-173_flexible_gpu_resource_attributes_ok_all_params/step2.flexible_gpu_resource_attributes_ok_all_params_update_delete_on_vm_deletion.tf
+++ b/tests/data/oapi/flexible_gpu/TF-173_flexible_gpu_resource_attributes_ok_all_params/step2.flexible_gpu_resource_attributes_ok_all_params_update_delete_on_vm_deletion.tf
@@ -1,7 +1,5 @@
 resource "outscale_flexible_gpu" "fGPU-1" {
   model_name            = "nvidia-p6"
   generation            = "v5"
-  subregion_name        = "${var.region}a"
   delete_on_vm_deletion = false
 }
-

--- a/tests/data/oapi/flexible_gpu/TF-177_flexible_gpu_datasource_attributes_ok/step1.flexible_gpu_datasource_attributes_ok.ref
+++ b/tests/data/oapi/flexible_gpu/TF-177_flexible_gpu_datasource_attributes_ok/step1.flexible_gpu_datasource_attributes_ok.ref
@@ -22,7 +22,7 @@
                         "model_name": "nvidia-p6",
                         "request_id": "########",
                         "state": "attached",
-                        "subregion_name": "eu-west-2a",
+                        "subregion_name": "########",
                         "vm_id": "##id-1##"
                     },
                     "sensitive_attributes": [],
@@ -47,7 +47,7 @@
                         "model_name": "nvidia-p6",
                         "request_id": "########",
                         "state": "attached",
-                        "subregion_name": "eu-west-2a",
+                        "subregion_name": "########",
                         "vm_id": "##id-1##"
                     },
                     "sensitive_attributes": [],
@@ -72,7 +72,7 @@
                         "model_name": "nvidia-p6",
                         "request_id": "########",
                         "state": "attached",
-                        "subregion_name": "eu-west-2a",
+                        "subregion_name": "########",
                         "vm_id": "##id-1##"
                     },
                     "sensitive_attributes": [],
@@ -95,7 +95,7 @@
                         "id": "##id-0##",
                         "model_name": "nvidia-p6",
                         "state": "allocated",
-                        "subregion_name": "eu-west-2a",
+                        "subregion_name": "########",
                         "timeouts": null,
                         "vm_id": ""
                     },

--- a/tests/data/oapi/flexible_gpu/TF-177_flexible_gpu_datasource_attributes_ok/step1.flexible_gpu_datasource_attributes_ok.tf
+++ b/tests/data/oapi/flexible_gpu/TF-177_flexible_gpu_datasource_attributes_ok/step1.flexible_gpu_datasource_attributes_ok.tf
@@ -20,7 +20,6 @@ resource "outscale_vm" "MaVM" {
 resource "outscale_flexible_gpu" "fGPU-1" {
   model_name            = "nvidia-p6"
   generation            = var.fgpu_gen
-  subregion_name        = "${var.region}a"
   delete_on_vm_deletion = false
 }
 
@@ -55,10 +54,6 @@ data "outscale_flexible_gpu" "data-fGPU-2" {
   filter {
     name   = "model_names"
     values = ["nvidia-p6"]
-  }
-  filter {
-    name   = "subregion_names"
-    values = ["${var.region}a"]
   }
   filter {
     name   = "flexible_gpu_ids"

--- a/tests/data/oapi/flexible_gpu/TF-177_flexible_gpu_datasource_attributes_ok/step2.flexible_gpu_datasource_attributes_ok.ref
+++ b/tests/data/oapi/flexible_gpu/TF-177_flexible_gpu_datasource_attributes_ok/step2.flexible_gpu_datasource_attributes_ok.ref
@@ -22,7 +22,7 @@
                         "model_name": "nvidia-p6",
                         "request_id": "########",
                         "state": "attached",
-                        "subregion_name": "eu-west-2a",
+                        "subregion_name": "########",
                         "vm_id": "##id-1##"
                     },
                     "sensitive_attributes": [],
@@ -47,7 +47,7 @@
                         "model_name": "nvidia-p6",
                         "request_id": "########",
                         "state": "attached",
-                        "subregion_name": "eu-west-2a",
+                        "subregion_name": "########",
                         "vm_id": "##id-1##"
                     },
                     "sensitive_attributes": [],
@@ -72,7 +72,7 @@
                         "model_name": "nvidia-p6",
                         "request_id": "########",
                         "state": "attached",
-                        "subregion_name": "eu-west-2a",
+                        "subregion_name": "########",
                         "vm_id": "##id-1##"
                     },
                     "sensitive_attributes": [],
@@ -95,7 +95,7 @@
                         "id": "##id-0##",
                         "model_name": "nvidia-p6",
                         "state": "attached",
-                        "subregion_name": "eu-west-2a",
+                        "subregion_name": "########",
                         "timeouts": null,
                         "vm_id": "##id-1##"
                     },

--- a/tests/data/oapi/flexible_gpu/TF-177_flexible_gpu_datasource_attributes_ok/step2.flexible_gpu_datasource_attributes_ok.tf
+++ b/tests/data/oapi/flexible_gpu/TF-177_flexible_gpu_datasource_attributes_ok/step2.flexible_gpu_datasource_attributes_ok.tf
@@ -20,7 +20,6 @@ resource "outscale_vm" "MaVM" {
 resource "outscale_flexible_gpu" "fGPU-1" {
   model_name            = "nvidia-p6"
   generation            = var.fgpu_gen
-  subregion_name        = "${var.region}a"
   delete_on_vm_deletion = true
 }
 
@@ -55,10 +54,6 @@ data "outscale_flexible_gpu" "data-fGPU-2" {
   filter {
     name   = "model_names"
     values = ["nvidia-p6"]
-  }
-  filter {
-    name   = "subregion_names"
-    values = ["${var.region}a"]
   }
   filter {
     name   = "flexible_gpu_ids"

--- a/tests/data/oapi/flexible_gpu_link/TF-174_flexible_gpu_link_resource_attributes_ok/step1.flexible_gpu_link_resource_attributes_ok.ref
+++ b/tests/data/oapi/flexible_gpu_link/TF-174_flexible_gpu_link_resource_attributes_ok/step1.flexible_gpu_link_resource_attributes_ok.ref
@@ -20,7 +20,7 @@
                         "id": "##id-0##",
                         "model_name": "nvidia-p6",
                         "state": "allocated",
-                        "subregion_name": "eu-west-2a",
+                        "subregion_name": "########",
                         "timeouts": null,
                         "vm_id": ""
                     },

--- a/tests/data/oapi/flexible_gpu_link/TF-174_flexible_gpu_link_resource_attributes_ok/step1.flexible_gpu_link_resource_attributes_ok.tf
+++ b/tests/data/oapi/flexible_gpu_link/TF-174_flexible_gpu_link_resource_attributes_ok/step1.flexible_gpu_link_resource_attributes_ok.tf
@@ -19,7 +19,6 @@ resource "outscale_vm" "MaVM" {
 resource "outscale_flexible_gpu" "fGPU-1" {
   model_name            = "nvidia-p6"
   generation            = var.fgpu_gen
-  subregion_name        = "${var.region}a"
   delete_on_vm_deletion = true
 }
 

--- a/tests/data/oapi/flexible_gpus/TF-175_flexible_gpus_datasource_attributes_ok/step1.flexible_gpus_datasource_attributes_ok.ref
+++ b/tests/data/oapi/flexible_gpus/TF-175_flexible_gpus_datasource_attributes_ok/step1.flexible_gpus_datasource_attributes_ok.ref
@@ -22,7 +22,7 @@
                         "model_name": "nvidia-p6",
                         "request_id": "########",
                         "state": "attached",
-                        "subregion_name": "eu-west-2a",
+                        "subregion_name": "########",
                         "vm_id": "##id-1##"
                     },
                     "sensitive_attributes": [],
@@ -47,7 +47,7 @@
                         "model_name": "nvidia-p6",
                         "request_id": "########",
                         "state": "attached",
-                        "subregion_name": "eu-west-2a",
+                        "subregion_name": "########",
                         "vm_id": "##id-1##"
                     },
                     "sensitive_attributes": [],
@@ -108,7 +108,7 @@
                         "id": "##id-0##",
                         "model_name": "nvidia-p6",
                         "state": "allocated",
-                        "subregion_name": "eu-west-2a",
+                        "subregion_name": "########",
                         "timeouts": null,
                         "vm_id": ""
                     },
@@ -132,7 +132,7 @@
                         "id": "##id-2##",
                         "model_name": "nvidia-p6",
                         "state": "allocated",
-                        "subregion_name": "eu-west-2a",
+                        "subregion_name": "########",
                         "timeouts": null,
                         "vm_id": ""
                     },

--- a/tests/data/oapi/flexible_gpus/TF-175_flexible_gpus_datasource_attributes_ok/step1.flexible_gpus_datasource_attributes_ok.tf
+++ b/tests/data/oapi/flexible_gpus/TF-175_flexible_gpus_datasource_attributes_ok/step1.flexible_gpus_datasource_attributes_ok.tf
@@ -19,14 +19,12 @@ resource "outscale_vm" "MaVM" {
 resource "outscale_flexible_gpu" "fGPU-1" {
   model_name            = "nvidia-p6"
   generation            = var.fgpu_gen
-  subregion_name        = "${var.region}a"
   delete_on_vm_deletion = true
 }
 
 resource "outscale_flexible_gpu" "fGPU-2" {
   model_name            = "nvidia-p6"
   generation            = var.fgpu_gen
-  subregion_name        = "${var.region}a"
   delete_on_vm_deletion = true
 }
 
@@ -60,10 +58,6 @@ data "outscale_flexible_gpu" "data-fGPU-2" {
   filter {
     name   = "model_names"
     values = ["nvidia-p6"]
-  }
-  filter {
-    name   = "subregion_names"
-    values = ["${var.region}a"]
   }
   filter {
     name   = "flexible_gpu_ids"

--- a/tests/test_provider_oapi_config.py
+++ b/tests/test_provider_oapi_config.py
@@ -62,6 +62,7 @@ OAPI_IGNORE_TYPE_ELEMENTS = {
     "outscale_net_peering_acceptation": {"expiration_date"},
     "outscale_server_certificate": {"name"},
     "outscale_vm": {"state", "state_reason"},
+    "outscale_flexible_gpu": {"subregion_name"},
 }
 
 OAPI_ID_PREFIXES = [


### PR DESCRIPTION
## Description

`subregion_name` attribute is now optional and enables the user to omit the subregion at creation. The provider will find the first available AZ which has capacity for the requested fGPU

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [X] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [X] Manual testing
- [ ] Unit tests
- [X] Acceptance tests
- [X] Integration tests
- [ ] Not tested yet

## Checklist

* [X] I have followed the [Contributing Guidelines](CONTRIBUTING.md)
* [X] I have added tests or explained why they are not needed
* [X] I have updated relevant documentation (README, examples, etc.)
* [X] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [X] My commits include appropriate [Gitmoji](https://gitmoji.dev/)
