### PR TITLE
🐛 fix(config): profile/config_file env values were ignored

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -56,11 +56,7 @@ func (cfg Config) ToOSCOption() profile.Option {
 // NewProfile merges profile values in the following order:
 // provider config -> selected profile file -> environment values for any fields that are still unset
 func (cfg Config) NewProfile(configOption profile.Option) (*profile.Profile, error) {
-	opts := []profile.Option{configOption, profile.MergeWith(profile.FromEnv())}
-
-	if cfg.Profile != "" || cfg.ConfigFile != "" {
-		opts = []profile.Option{configOption, profile.MergeWith(profile.FromFile(cfg.Profile, cfg.ConfigFile)), profile.MergeWith(profile.FromEnv())}
-	}
+	opts := []profile.Option{configOption, profile.MergeWith(profile.FromFile(cfg.Profile, cfg.ConfigFile)), profile.MergeWith(profile.FromEnv())}
 
 	return profile.New(opts...)
 }

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -175,6 +175,97 @@ func TestOSCApiEndpoint(t *testing.T) {
 	})
 }
 
+func TestProfileEnvSet(t *testing.T) {
+	clearProfileEnv(t)
+
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	configFile := profile.ConfigFile{
+		Path: configPath,
+		Profiles: map[string]profile.Profile{
+			"default": {
+				AccessKey:      "default-ak",
+				SecretKey:      "default-sk",
+				Region:         "default-region",
+				X509ClientCert: "/default/cert.pem",
+				X509ClientKey:  "/default/key.pem",
+				Endpoints: profile.Endpoint{
+					API: "https://default.api",
+				},
+			},
+			"main": {
+				AccessKey: "main-ak",
+				SecretKey: "main-sk",
+				Region:    "main-region",
+				Endpoints: profile.Endpoint{
+					API: "https://main.api",
+				},
+			},
+		},
+	}
+	require.NoError(t, configFile.Save())
+
+	t.Setenv("OSC_ACCESS_KEY", "env-ak")
+	t.Setenv("OSC_SECRET_KEY", "env-sk")
+	t.Setenv("OSC_REGION", "env-region")
+	t.Setenv("OSC_ENDPOINT_API", "https://env.api")
+	t.Setenv("OSC_PROFILE", "main")
+	t.Setenv("OSC_CONFIG_FILE", configPath)
+
+	cfg := client.Config{
+		AccessKey: "config-ak",
+	}
+
+	p, err := cfg.NewProfile(cfg.ToOSCOption())
+	require.NoError(t, err)
+
+	assert.Equal(t, "config-ak", p.AccessKey, "access key")
+	assert.Equal(t, "main-sk", p.SecretKey, "secret key")
+	assert.Equal(t, "main-region", p.Region, "region")
+	assert.Equal(t, "https://main.api", p.Endpoints.API, "api endpoint")
+	assert.Equal(t, "https", p.Protocol, "protocol")
+}
+
+func TestProfileEnvUnset(t *testing.T) {
+	clearProfileEnv(t)
+
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	configFile := profile.ConfigFile{
+		Path: configPath,
+		Profiles: map[string]profile.Profile{
+			"default": {
+				AccessKey:      "default-ak",
+				SecretKey:      "default-sk",
+				Region:         "default-region",
+				X509ClientCert: "/default/cert.pem",
+				X509ClientKey:  "/default/key.pem",
+				Endpoints: profile.Endpoint{
+					API: "https://default.api",
+				},
+			},
+		},
+	}
+	require.NoError(t, configFile.Save())
+
+	t.Setenv("OSC_ACCESS_KEY", "env-ak")
+	t.Setenv("OSC_SECRET_KEY", "env-sk")
+	t.Setenv("OSC_REGION", "env-region")
+	t.Setenv("OSC_ENDPOINT_API", "https://env.api")
+	t.Setenv("OSC_CONFIG_FILE", configPath)
+
+	cfg := client.Config{
+		AccessKey: "config-ak",
+	}
+
+	p, err := cfg.NewProfile(cfg.ToOSCOption())
+	require.NoError(t, err)
+
+	assert.Equal(t, "config-ak", p.AccessKey, "access key")
+	assert.Equal(t, "default-sk", p.SecretKey, "secret key")
+	assert.Equal(t, "default-region", p.Region, "region")
+	assert.Equal(t, "https://default.api", p.Endpoints.API, "api endpoint")
+	assert.Equal(t, "https", p.Protocol, "protocol")
+}
+
 func clearProfileEnv(t *testing.T) {
 	t.Helper()
 


### PR DESCRIPTION
## Description

- When declaring an empty provider block configuration, the provider did
  not load the `OSC_PROFILE` and `OSC_CONFIG_FILE` environment
  variables

## Type of Change

Please check the relevant option(s):

- [X] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [X] Manual testing
- [ ] Unit tests
- [X] Acceptance tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [X] I have followed the [Contributing Guidelines](CONTRIBUTING.md)
* [X] I have added tests or explained why they are not needed
* [X] I have updated relevant documentation (README, examples, etc.)
* [X] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [X] My commits include appropriate [Gitmoji](https://gitmoji.dev/)
