### PR TITLE
🐛 fix(config): remove global region deprecation

### DIFF
--- a/provider/framework.go
+++ b/provider/framework.go
@@ -162,9 +162,8 @@ func (p *FrameworkProvider) Schema(ctx context.Context, req provider.SchemaReque
 				Description: "The Secret Key ID for API operations.",
 			},
 			"region": schema.StringAttribute{
-				Optional:           true,
-				DeprecationMessage: deprecatedMsg("region"),
-				Description:        "The Region for API operations.",
+				Optional:    true,
+				Description: "The Region for API operations.",
 			},
 			"config_file": schema.StringAttribute{
 				Optional:    true,
@@ -391,6 +390,8 @@ func (data *ProviderModel) buildOSCConfig(ctx context.Context) (config client.Co
 	if fwhelpers.IsSet(data.Insecure) {
 		config.Insecure = data.Insecure.ValueBool()
 	}
+
+	// fallback to global attributes
 	if config.Region == "" && fwhelpers.IsSet(data.Region) {
 		config.Region = data.Region.ValueString()
 	}
@@ -415,6 +416,8 @@ func (data *ProviderModel) buildOKSConfig(ctx context.Context) (config client.Co
 	if config.OKSEndpoint == "" && len(data.Endpoints) > 0 && fwhelpers.IsSet(data.Endpoints[0].OKS) {
 		config.OKSEndpoint = data.Endpoints[0].OKS.ValueString()
 	}
+
+	// fallback to global attributes
 	if config.Region == "" && fwhelpers.IsSet(data.Region) {
 		config.Region = data.Region.ValueString()
 	}

--- a/provider/sdkv2.go
+++ b/provider/sdkv2.go
@@ -33,7 +33,6 @@ func Provider() *schema.Provider {
 			"region": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Deprecated:  deprecatedMsg("region"),
 				Description: "The Region for API operations.",
 			},
 			"endpoints": {


### PR DESCRIPTION
## Description

- Removes the global `region` depreciation to allow user to only
  configure a global `region` value, and override with service specific region
  attribute

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [X] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [X] Manual testing
- [ ] Unit tests
- [ ] Acceptance tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [X] I have followed the [Contributing Guidelines](CONTRIBUTING.md)
* [X] I have added tests or explained why they are not needed
* [X] I have updated relevant documentation (README, examples, etc.)
* [X] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [X] My commits include appropriate [Gitmoji](https://gitmoji.dev/)
