### PR TITLE
👽 refactor: increase vpn_connection & load_balancer default create timeout

### DIFF
--- a/docs/resources/load_balancer.md
+++ b/docs/resources/load_balancer.md
@@ -225,7 +225,7 @@ To only allow traffic from load balancers, add a security group rule that specif
 
 The `timeouts` block enables you to configure [timeouts](https://developer.hashicorp.com/terraform/language/resources/configure#define-operation-timeouts) for certain actions:
 
-* `create` - Defaults to 10 minutes.
+* `create` - Defaults to 15 minutes.
 * `read` - Defaults to 5 minutes.
 * `update` - Defaults to 10 minutes.
 * `delete` - Defaults to 5 minutes.

--- a/docs/resources/vpn_connection.md
+++ b/docs/resources/vpn_connection.md
@@ -86,7 +86,7 @@ The following attributes are exported:
 
 The `timeouts` block enables you to configure [timeouts](https://developer.hashicorp.com/terraform/language/resources/configure#define-operation-timeouts) for certain actions:
 
-* `create` - Defaults to 10 minutes.
+* `create` - Defaults to 15 minutes.
 * `read` - Defaults to 5 minutes.
 * `update` - Defaults to 10 minutes.
 * `delete` - Defaults to 5 minutes.

--- a/internal/services/oapi/resource_load_balancer.go
+++ b/internal/services/oapi/resource_load_balancer.go
@@ -42,6 +42,8 @@ const (
 	loadBalancerErrUpdateListeners = "Unable to update Load Balancer listeners"
 	loadBalancerErrDelete          = "Unable to delete Load Balancer"
 	loadBalancerErrWait            = "Unable to wait for Load Balancer state"
+
+	loadBalancerCreateTimeout = 15 * time.Minute
 )
 
 type loadBalancerModel struct {
@@ -447,7 +449,7 @@ func (r *loadBalancerResource) Create(ctx context.Context, req resource.CreateRe
 		return
 	}
 
-	timeout, diags := data.Timeouts.Create(ctx, CreateDefaultTimeout)
+	timeout, diags := data.Timeouts.Create(ctx, loadBalancerCreateTimeout)
 	if fwhelpers.CheckDiags(resp, diags) {
 		return
 	}

--- a/internal/services/oapi/resource_vpn_connection.go
+++ b/internal/services/oapi/resource_vpn_connection.go
@@ -36,6 +36,8 @@ const (
 	vpnConnectionErrCreate = "Unable to create VPN Connection"
 	vpnConnectionErrDelete = "Unable to delete VPN Connection"
 	vpnConnectionErrWait   = "Unable to wait for VPN Connection state"
+
+	vpnConnectionCreateTimeout = 15 * time.Minute
 )
 
 type vpnConnectionModel struct {
@@ -238,7 +240,7 @@ func (r *vpnConnectionResource) Create(ctx context.Context, req resource.CreateR
 		return
 	}
 
-	timeout, diags := data.Timeouts.Create(ctx, CreateDefaultTimeout)
+	timeout, diags := data.Timeouts.Create(ctx, vpnConnectionCreateTimeout)
 	if fwhelpers.CheckDiags(resp, diags) {
 		return
 	}


### PR DESCRIPTION
## Description

- Default timeout are getting reached more then wanted on daily CI runs 

Both `vpn_connection` and `load_balancer` resource are defaulting to 15 minutes of timeout creation

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [X] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [ ] Manual testing
- [ ] Unit tests
- [ ] Acceptance tests
- [ ] Integration tests
- [X] Not tested yet

## Checklist

* [X] I have followed the [Contributing Guidelines](CONTRIBUTING.md)
* [X] I have added tests or explained why they are not needed
* [X] I have updated relevant documentation (README, examples, etc.)
* [X] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [X] My commits include appropriate [Gitmoji](https://gitmoji.dev/)
